### PR TITLE
unit tests rocm

### DIFF
--- a/Dockerfile_rocm.ci
+++ b/Dockerfile_rocm.ci
@@ -57,8 +57,8 @@ WORKDIR ${STAGE_DIR}
 ENV NVTE_FRAMEWORK=pytorch
 ENV PYTORCH_ROCM_ARCH=${PYTORCH_ROCM_ARCH_OVERRIDE}
 ENV NVTE_USE_HIPBLASLT=1
-RUN git clone --recursive https://github.com/ROCmSoftwarePlatform/TransformerEngine-private.git &&\
-    cd TransformerEngine-private &&\
+RUN git clone --recursive https://github.com/ROCm/TransformerEngine.git &&\
+    cd TransformerEngine &&\
     pip install .
 
 WORKDIR $WORKSPACE_DIR

--- a/Dockerfile_rocm_ci
+++ b/Dockerfile_rocm_ci
@@ -1,0 +1,70 @@
+ARG BASE_DOCKER=rocm/pytorch:latest
+FROM $BASE_DOCKER
+
+ARG PYTORCH_ROCM_ARCH_OVERRIDE="gfx942"
+ENV WORKSPACE_DIR=/workspace
+ENV STAGE_DIR=/workspace/installs
+RUN mkdir -p $WORKSPACE_DIR
+RUN mkdir -p ${STAGE_DIR}
+WORKDIR $WORKSPACE_DIR
+
+RUN pip3 install \
+numpy==1.26.4 \
+scipy \
+einops \
+flask-restful \
+nltk \
+pytest \
+pytest-cov \
+pytest_mock \
+pytest-csv \
+pytest-random-order \
+sentencepiece \
+wrapt \
+zarr \
+wandb \
+tensorstore==0.1.45 \
+pytest_mock \
+pybind11 \
+setuptools==69.5.1 \
+datasets \
+tiktoken \
+pynvml
+
+RUN pip3 install "huggingface_hub[cli]"
+RUN python3 -m nltk.downloader punkt_tab
+
+
+# Install Causal-Conv1d and its dependencies
+WORKDIR ${STAGE_DIR}
+ENV CAUSAL_CONV1D_FORCE_BUILD=TRUE
+ENV MAMBA_FORCE_BUILD=TRUE
+ENV HIP_ARCHITECTURES=${PYTORCH_ROCM_ARCH_OVERRIDE}
+RUN git clone https://github.com/Dao-AILab/causal-conv1d causal-conv1d &&\
+    cd causal-conv1d &&\
+    git show --oneline -s &&\
+    pip install .
+
+# Install mamba
+WORKDIR ${STAGE_DIR}
+RUN git clone https://github.com/state-spaces/mamba mamba &&\
+    cd mamba &&\
+    git show --oneline -s &&\
+    pip install --no-build-isolation .
+
+# Clone TE repo and submodules
+WORKDIR ${STAGE_DIR}
+ENV NVTE_FRAMEWORK=pytorch
+ENV PYTORCH_ROCM_ARCH=${PYTORCH_ROCM_ARCH_OVERRIDE}
+ENV NVTE_USE_HIPBLASLT=1
+RUN git clone --recursive https://github.com/ROCmSoftwarePlatform/TransformerEngine-private.git &&\
+    cd TransformerEngine-private &&\
+    pip install .
+
+WORKDIR $WORKSPACE_DIR
+COPY . Megatron-LM
+WORKDIR $WORKSPACE_DIR/Megatron-LM
+
+# record configuration for posterity
+RUN pip list
+

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ pipeline {
                 }
             }
 
-        stage('Run Docker Container') {
+        stage('Run Unit Tests') {
             steps {
                 script {
                     wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'xterm']) {

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,7 +3,7 @@
 markers =
     internal: mark a test as a test to private/internal functions.
     failing_on_rocm: Currently Failing Tests on Rocm
+    failing_on_rocm_mi250: Tests failing on MI250
 
 addopts =
     --ignore tests/unit_tests/test_utilities.py
-    -m "not failing_on_rocm and not flaky and not internal"

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,8 @@
 [pytest]
 markers =
     internal: mark a test as a test to private/internal functions.
+    failing_on_rocm: Currently Failing Tests on Rocm
+
+addopts =
+    --ignore tests/unit_tests/test_utilities.py
+    -m "not failing_on_rocm and not flaky and not internal"

--- a/run_unit_tests.sh
+++ b/run_unit_tests.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -x
+export HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+torchrun --nproc_per_node=8 -m pytest --color=yes -m "not flaky and not internal and not failing_on_rocm_mi250 and not failing_on_rocm" --csv output/test_report.csv tests/unit_tests/

--- a/tests/unit_tests/dist_checkpointing/models/test_moe_experts.py
+++ b/tests/unit_tests/dist_checkpointing/models/test_moe_experts.py
@@ -102,6 +102,7 @@ class TestExpertLayerReconfiguration:
             (False, (1, 1, 4), (8, 1, 1), True),
         ],
     )
+    @pytest.mark.failing_on_rocm
     @pytest.mark.parametrize("expert_type", expert_type)
     def test_parallel_reconfiguration_e2e(
         self, tmp_path_dist_ckpt, src_tp_pp_exp, dest_tp_pp_exp, use_glu, use_fpsl, expert_type
@@ -182,6 +183,7 @@ class TestExpertLayerReconfiguration:
         ],
     )
     @pytest.mark.parametrize("src_module,dest_module", src_dest_expert_type)
+    @pytest.mark.failing_on_rocm
     def test_sequential_grouped_mlp_interchangeable(
         self, tmp_path_dist_ckpt, src_tp_pp_exp, dest_tp_pp_exp, use_glu, src_module, dest_module
     ):

--- a/tests/unit_tests/dist_checkpointing/test_fp8.py
+++ b/tests/unit_tests/dist_checkpointing/test_fp8.py
@@ -18,8 +18,10 @@ from tests.unit_tests.test_utilities import Utils
 
 
 class TestFP8:
+
     @pytest.mark.parametrize('dtype', ['bf16', 'fp16', 'fp8'])
     @pytest.mark.parametrize('src_rank', [0, 6])
+    @pytest.mark.failing_on_rocm
     def test_simple_broadcast(self, dtype, src_rank):
         Utils.initialize_model_parallel()
 
@@ -52,6 +54,7 @@ class TestFP8:
         ],
     )
     @pytest.mark.flaky
+    @pytest.mark.failing_on_rocm
     def test_fp8_save_load(
         self, tmp_path_dist_ckpt, use_fpsl, src_tp_pp, dest_tp_pp, load_exchange_algo
     ):

--- a/tests/unit_tests/dist_checkpointing/test_fp8.py
+++ b/tests/unit_tests/dist_checkpointing/test_fp8.py
@@ -18,7 +18,6 @@ from tests.unit_tests.test_utilities import Utils
 
 
 class TestFP8:
-
     @pytest.mark.parametrize('dtype', ['bf16', 'fp16', 'fp8'])
     @pytest.mark.parametrize('src_rank', [0, 6])
     @pytest.mark.failing_on_rocm

--- a/tests/unit_tests/dist_checkpointing/test_nonpersistent.py
+++ b/tests/unit_tests/dist_checkpointing/test_nonpersistent.py
@@ -30,6 +30,7 @@ class TestNonPersistentSaveAndLoad:
 
     @pytest.mark.parametrize(('tp,pp'), [(2, 4)])
     @pytest.mark.flaky
+    @pytest.mark.failing_on_rocm
     def test_basic_save_load_scenarios(self, tmp_path_dist_ckpt, tp, pp):
         Utils.initialize_model_parallel(tp, pp)
         num_floating_point_operations_so_far = 0
@@ -119,6 +120,7 @@ class TestNonPersistentSaveAndLoad:
 class TestLegacySaveAndLoad:
     @pytest.mark.parametrize(('tp,pp'), [(2, 4)])
     @pytest.mark.flaky
+    @pytest.mark.failing_on_rocm
     def test_basic_save_load_scenario(self, tmp_path_dist_ckpt, tp, pp):
         Utils.initialize_model_parallel(tp, pp)
         num_floating_point_operations_so_far = 0

--- a/tests/unit_tests/dist_checkpointing/test_optimizer.py
+++ b/tests/unit_tests/dist_checkpointing/test_optimizer.py
@@ -517,6 +517,7 @@ class TestOptimizerResharding:
             ((2, 1, 2), (1, 1, 8)),
         ],
     )
+    @pytest.mark.failing_on_rocm
     def test_chained_optimizer_resharding(
         self,
         tmp_path_dist_ckpt,

--- a/tests/unit_tests/inference/test_modelopt_gpt_model.py
+++ b/tests/unit_tests/inference/test_modelopt_gpt_model.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+import pytest
 from megatron.core.inference.modelopt_support.gpt.model_specs import get_gpt_layer_modelopt_spec
 from megatron.core.inference.modelopt_support.gpt.state_dict_hooks import (
     mcore_gpt_load_te_state_dict_pre_hook,
@@ -32,6 +33,7 @@ class TestModelOptGPTModel:
             max_sequence_length=4,
         )
 
+    @pytest.mark.failing_on_rocm_mi250
     def test_load_te_state_dict_pre_hook(self):
         handle = self.modelopt_gpt_model._register_load_state_dict_pre_hook(
             mcore_gpt_load_te_state_dict_pre_hook

--- a/tests/unit_tests/models/test_mamba_model.py
+++ b/tests/unit_tests/models/test_mamba_model.py
@@ -56,6 +56,7 @@ class TestMambaModel:
         assert self.model.decoder.input_tensor.shape[1] == micro_batch_size
         assert self.model.decoder.input_tensor.shape[2] == config.hidden_size
 
+    @pytest.mark.failing_on_rocm
     def test_forward(self):
         config: TransformerConfig = self.model.config
         sequence_length = self.model.max_sequence_length
@@ -78,6 +79,7 @@ class TestMambaModel:
         assert logits.shape[1] == sequence_length
         assert logits.shape[2] == self.model.vocab_size
 
+    @pytest.mark.failing_on_rocm
     def test_inference(self):
         config: TransformerConfig = self.model.config
         micro_batch_size = 2

--- a/tests/unit_tests/test_utils.py
+++ b/tests/unit_tests/test_utils.py
@@ -110,7 +110,7 @@ def test_cross_check_param_hashes_across_dp_replicas():
     # Teardown.
     _deinit_distributed()
 
-
+@pytest.mark.failing_on_rocm
 def test_straggler_detector():
     world = int(os.getenv('WORLD_SIZE', '1'))
     rank = int(os.getenv('RANK', '0'))

--- a/tests/unit_tests/transformer/test_attention.py
+++ b/tests/unit_tests/transformer/test_attention.py
@@ -37,7 +37,7 @@ class TestParallelAttention:
     def test_cpu_forward(self):
         # we can't currently do this because the global memory buffer is on GPU
         pass
-
+    @pytest.mark.failing_on_rocm
     def test_gpu_forward(self):
 
         config = self.parallel_attention.config
@@ -61,7 +61,7 @@ class TestParallelAttention:
         assert output.shape[1] == micro_batch_size
         assert output.shape[2] == config.hidden_size
         assert bias.shape[0] == config.hidden_size
-
+    @pytest.mark.failing_on_rocm
     def test_fused_rope_gpu_forward(self):
         self.parallel_attention.config.apply_rope_fusion = True
         config = self.parallel_attention.config
@@ -90,7 +90,7 @@ class TestParallelAttention:
         assert output.shape[2] == config.hidden_size
         assert bias.shape[0] == config.hidden_size
         self.parallel_attention.config.apply_rope_fusion = False
-
+    @pytest.mark.failing_on_rocm
     def test_checkpointed_gpu_forward(self):
         transformer_config = self.transformer_config
         transformer_config.recompute_granularity = 'selective'

--- a/tests/unit_tests/transformer/test_retro_attention.py
+++ b/tests/unit_tests/transformer/test_retro_attention.py
@@ -3,6 +3,7 @@
 import types
 
 import torch
+import pytest
 
 from megatron.core.models.retro import RetroConfig, get_retro_decoder_block_spec
 from megatron.core.models.retro.decoder_attention import (
@@ -80,6 +81,7 @@ class TestRetroAttention:
     def teardown_method(self, method):
         Utils.destroy_model_parallel()
 
+    @pytest.mark.failing_on_rocm
     def test_constructor(self):
 
         config = self.get_config()
@@ -101,6 +103,7 @@ class TestRetroAttention:
         assert get_nparams(modules.encoder_bda) == 0
         assert get_nparams(modules.encoder_norm) == 32
 
+    @pytest.mark.failing_on_rocm
     def test_cpu_forward(self):
         # we can't currently do this because the global memory buffer is on GPU
         pass
@@ -190,7 +193,7 @@ class TestRetroAttention:
             config.retro_num_neighbors * micro_batch_size * n_chunks_per_sample,
             config.hidden_size,
         )
-
+    @pytest.mark.failing_on_rocm
     def test_gpu_forward(self):
         for recompute_granularity in (None, 'selective'):
             for use_transformer_engine in (True, False):

--- a/tests/unit_tests/transformer/test_spec_customization.py
+++ b/tests/unit_tests/transformer/test_spec_customization.py
@@ -132,6 +132,7 @@ class TestSpecCustomization:
         bda_op = build_module(self.bda_spec)
         assert id(bda_op) == id(get_bias_dropout_add)
 
+    @pytest.mark.failing_on_rocm
     def test_sliding_window_attention(self):
         if not is_te_min_version("1.2.0"):
             print("SWA not tested because TE version is not >= 1.2.0", file=sys.stderr)

--- a/tests/unit_tests/transformer/test_transformer_block.py
+++ b/tests/unit_tests/transformer/test_transformer_block.py
@@ -66,12 +66,14 @@ class TestParallelTransformerBlock:
     def test_gpu_forward_full_checkpoint(self):
         self._run_full_checkpoint_test(fp8=None)
 
+    @pytest.mark.failing_on_rocm_mi250
     def test_gpu_forward_full_checkpoint_fp8(self):
         self._run_full_checkpoint_test(fp8="e4m3")
 
     def test_gpu_forward_selective_checkpoint(self):
         self._run_selective_checkpoint_test(fp8=None)
 
+    @pytest.mark.failing_on_rocm_mi250
     def test_gpu_forward_selective_checkpoint_fp8(self):
         self._run_selective_checkpoint_test(fp8="e4m3")
 


### PR DESCRIPTION
- Added marker "@pytest.mark.failing_on_rocm" for all failing tests on rocm.


[test_report_pytests.csv](https://github.com/user-attachments/files/17624104/test_report_pytests.csv)
[unit_test_logs.txt](https://github.com/user-attachments/files/17624105/unit_test_logs.txt)

------------------------- CSV report: test_report.csv --------------------------
**305 passed, 18 skipped, 270 deselected, 955 warnings in 160.58s (0:02:40) ===**

- **Total tests skipped for ROCM** 
 114 out of 593

