### PR TITLE
Remove the "extra_state" for TE DPA module

### DIFF
--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -706,6 +706,15 @@ class TEDotProductAttention(te.pytorch.DotProductAttention):
         else:
             return core_attn_out
 
+    def sharded_state_dict(self, prefix='', sharded_offsets=(), metadata=None):
+        state_dict = self.state_dict(prefix='', keep_vars=True)
+        # TE with version>=1.9 introduces an extra state in DotProductAttention Module
+        if is_te_min_version("1.9.0.dev0") and ('_extra_state' in state_dict):
+            state_dict.pop('_extra_state')
+        return make_sharded_tensors_for_checkpoint(
+            state_dict, prefix, {}, sharded_offsets
+        )
+
 
 if is_te_min_version("1.9.0.dev0"):
 


### PR DESCRIPTION
Remove the "extra_state" from the shared_state_dict of TEDotProductAttention module which was added from NVTE (ver >=1.9) , so that the dist checkpointing can ignore the weights for this extra_state for some earlier ckpts

Passed the manual pytest:
torchrun --nproc_per_node=8 -m pytest --color=yes -m "not flaky and not internal and not failing_on_rocm" --csv output/test_report.csv tests/unit_tests/
![image](https://github.com/user-attachments/assets/97cdf33b-05a4-4235-9188-b023330a3d65)
