### PR TITLE
use spawn instead of fork

### DIFF
--- a/megatron/core/dist_checkpointing/strategies/async_utils.py
+++ b/megatron/core/dist_checkpointing/strategies/async_utils.py
@@ -95,7 +95,7 @@ class DistributedAsyncCaller:
             f"rank: {torch.distributed.get_rank()}, takes {end_sync - start_sync} to finish D2H "
         )
 
-        ctx = mp.get_context('fork')
+        ctx = mp.get_context('spawn')
         self.start_time = time()
         self.process = ctx.Process(target=async_fn, args=save_args)
         self.process.start()

--- a/tests/unit_tests/dist_checkpointing/models/test_moe_experts.py
+++ b/tests/unit_tests/dist_checkpointing/models/test_moe_experts.py
@@ -102,7 +102,6 @@ class TestExpertLayerReconfiguration:
             (False, (1, 1, 4), (8, 1, 1), True),
         ],
     )
-    @pytest.mark.failing_on_rocm
     @pytest.mark.parametrize("expert_type", expert_type)
     def test_parallel_reconfiguration_e2e(
         self, tmp_path_dist_ckpt, src_tp_pp_exp, dest_tp_pp_exp, use_glu, use_fpsl, expert_type
@@ -183,7 +182,6 @@ class TestExpertLayerReconfiguration:
         ],
     )
     @pytest.mark.parametrize("src_module,dest_module", src_dest_expert_type)
-    @pytest.mark.failing_on_rocm
     def test_sequential_grouped_mlp_interchangeable(
         self, tmp_path_dist_ckpt, src_tp_pp_exp, dest_tp_pp_exp, use_glu, src_module, dest_module
     ):

--- a/tests/unit_tests/dist_checkpointing/test_nonpersistent.py
+++ b/tests/unit_tests/dist_checkpointing/test_nonpersistent.py
@@ -30,7 +30,6 @@ class TestNonPersistentSaveAndLoad:
 
     @pytest.mark.parametrize(('tp,pp'), [(2, 4)])
     @pytest.mark.flaky
-    @pytest.mark.failing_on_rocm
     def test_basic_save_load_scenarios(self, tmp_path_dist_ckpt, tp, pp):
         Utils.initialize_model_parallel(tp, pp)
         num_floating_point_operations_so_far = 0
@@ -120,7 +119,6 @@ class TestNonPersistentSaveAndLoad:
 class TestLegacySaveAndLoad:
     @pytest.mark.parametrize(('tp,pp'), [(2, 4)])
     @pytest.mark.flaky
-    @pytest.mark.failing_on_rocm
     def test_basic_save_load_scenario(self, tmp_path_dist_ckpt, tp, pp):
         Utils.initialize_model_parallel(tp, pp)
         num_floating_point_operations_so_far = 0

--- a/tests/unit_tests/dist_checkpointing/test_optimizer.py
+++ b/tests/unit_tests/dist_checkpointing/test_optimizer.py
@@ -517,7 +517,6 @@ class TestOptimizerResharding:
             ((2, 1, 2), (1, 1, 8)),
         ],
     )
-    @pytest.mark.failing_on_rocm
     def test_chained_optimizer_resharding(
         self,
         tmp_path_dist_ckpt,


### PR DESCRIPTION
https://pytorch.org/docs/stable/notes/multiprocessing.html

From the above documentation, it is recommended to use `spawn` instead of `fork` after CUDA or ROCm initialization. Apparently CUDA is more tolerable to this as this still worked on CUDA. 