### PR TITLE
[Perf] Skip creating attention mask in llama dataloader

### DIFF
--- a/examples/llama/train_llama2.sh
+++ b/examples/llama/train_llama2.sh
@@ -182,7 +182,8 @@ DATA_ARGS="
     --eval-interval 320000 \
     --eval-iters 10 \
     --num-workers $ds_works \
-    --mock-data
+    --mock-data \
+    --no-create-attention-mask-in-dataloader
 "
 #    --data-path $DATA_PATH \
 OUTPUT_ARGS="

--- a/examples/llama/train_llama3.sh
+++ b/examples/llama/train_llama3.sh
@@ -180,7 +180,8 @@ DATA_ARGS="
     --eval-interval 320000 \
     --eval-iters 10 \
     --num-workers $ds_works \
-    --mock-data
+    --mock-data \
+    --no-create-attention-mask-in-dataloader
 "
 #--data-path $DATA_PATH \
 OUTPUT_ARGS="


### PR DESCRIPTION
This patch is to skip creating attention mask in llama dataloader by adding flag **--no-create-attention-mask-in-dataloader**. With this patch, we can see multiple benefits below:
1) This could bring 4%~6% performance gain
2) Also address observed data loader crash issue when dealing with long sequence case e.g. https://github.com/NVIDIA/Megatron-LM/issues/1025
3) We also see new megatron model example adopt this flag as well. e.g. https://github.com/NVIDIA/Megatron-LM/blob/40db706d37a25787b0fb6b7b561327e5d2b4b2e4/examples/mamba/train.sh#L102