### PR TITLE
fix import error in arguments.py for fsdpv2 usage

### DIFF
--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -20,7 +20,7 @@ from megatron.core.models.retro.utils import (
 )
 from megatron.core.transformer import TransformerConfig, MLATransformerConfig
 from megatron.core.transformer.enums import AttnBackend
-from megatron.core.utils import is_torch_min_version
+from megatron.core.utils import get_torch_version, is_torch_min_version
 from megatron.training.activations import squared_relu
 from megatron.training.utils import update_use_dist_ckpt
 


### PR DESCRIPTION
Hi,

I've added the "get_torch_version" in the import, so that it won't raise import error or name error when experimenting with fsdpv2.
