### PR TITLE
Fixed configuration of both llama2 and llama3

### DIFF
--- a/examples/llama/train_llama2.sh
+++ b/examples/llama/train_llama2.sh
@@ -113,11 +113,11 @@ fi
 
 if [[ $MODEL_SIZE -eq 7 ]]; then #llama2-7B
         HIDDEN_SIZE=4096 # e.g. llama-13b: 5120
-        FFN_HIDDEN_SIZE=14336 # e.g. llama-13b: 13824
+        FFN_HIDDEN_SIZE=11008 # e.g. llama-13b: 13824
         NUM_LAYERS=32 # e.g. llama-13b: 40
         NUM_HEADS=32 # e.g. llama-13b: 40
         SEQ_LENGTH=$SEQ_LENGTH
-        NUM_KV_HEADS=8 # llama2 70B uses GQA
+        NUM_KV_HEADS=32 # No GQA for llama2 7b.
 elif [[ $MODEL_SIZE -eq 70 ]]; then
         HIDDEN_SIZE=8192 # e.g. llama-13b: 5120
         FFN_HIDDEN_SIZE=28672 # e.g. llama-13b: 13824

--- a/examples/llama/train_llama2.sh
+++ b/examples/llama/train_llama2.sh
@@ -91,7 +91,7 @@ if ! [ -f "$TOKENIZER_MODEL" ]; then
 wget -O $TOKENIZER_MODEL https://huggingface.co/NousResearch/Llama-2-7b-chat-hf/resolve/main/tokenizer.model
 fi
 
-MAX_POSITION_EMBEDDINGS=128000
+MAX_POSITION_EMBEDDINGS=4096
 
 DEFAULT_LOG_DIR="${EXPERIMENT_DIR}/${NNODES}nodes_rank${NODE_RANK}_train_${MODEL_SIZE}B_mbs${MBS}_bs${BS}_tp${TP}_pp${PP}_cp${CP}_iter${TOTAL_ITERS}/TE_FP8_${TE_FP8}/${TIME_STAMP}"
 LOG_DIR="${LOG_DIR:-${DEFAULT_LOG_DIR}}"

--- a/examples/llama/train_llama2.sh
+++ b/examples/llama/train_llama2.sh
@@ -125,7 +125,6 @@ elif [[ $MODEL_SIZE -eq 70 ]]; then
         NUM_HEADS=64 # e.g. llama-13b: 40
         NUM_KV_HEADS=8 # llama3 70B uses GQA
         SEQ_LENGTH=$SEQ_LENGTH
-        MAX_POSITION_EMBEDDINGS=$MAX_POSITION_EMBEDDINGS
 else
         echo "Model size not supported."
         exit 1

--- a/examples/llama/train_llama2.sh
+++ b/examples/llama/train_llama2.sh
@@ -116,7 +116,6 @@ if [[ $MODEL_SIZE -eq 7 ]]; then #llama2-7B
         FFN_HIDDEN_SIZE=11008 # e.g. llama-13b: 13824
         NUM_LAYERS=32 # e.g. llama-13b: 40
         NUM_HEADS=32 # e.g. llama-13b: 40
-        SEQ_LENGTH=$SEQ_LENGTH
         NUM_KV_HEADS=32 # No GQA for llama2 7b.
 elif [[ $MODEL_SIZE -eq 70 ]]; then
         HIDDEN_SIZE=8192 # e.g. llama-13b: 5120
@@ -124,7 +123,6 @@ elif [[ $MODEL_SIZE -eq 70 ]]; then
         NUM_LAYERS=80 # e.g. llama-13b: 40
         NUM_HEADS=64 # e.g. llama-13b: 40
         NUM_KV_HEADS=8 # llama3 70B uses GQA
-        SEQ_LENGTH=$SEQ_LENGTH
 else
         echo "Model size not supported."
         exit 1

--- a/examples/llama/train_llama3.sh
+++ b/examples/llama/train_llama3.sh
@@ -115,15 +115,13 @@ if [[ $MODEL_SIZE -eq 8 ]]; then #llama2-7B
         NUM_HEADS=32 # e.g. llama-13b: 40
         SEQ_LENGTH=$SEQ_LENGTH
         NUM_KV_HEADS=8 
-        MAX_POSITION_EMBEDDINGS=$MAX_POSITION_EMBEDDINGS
 elif [[ $MODEL_SIZE -eq 70 ]]; then
         HIDDEN_SIZE=8192 # e.g. llama-13b: 5120
         FFN_HIDDEN_SIZE=28672 # e.g. llama-13b: 13824
         NUM_LAYERS=80 # e.g. llama-13b: 40
         NUM_HEADS=64 # e.g. llama-13b: 40
         NUM_KV_HEADS=8 # llama3 70B uses GQA
-        SEQ_LENGTH=$SEQ_LENGTH
-        MAX_POSITION_EMBEDDINGS=$MAX_POSITION_EMBEDDINGS
+        SEQ_LENGTH=$SEQ_LENGTH  
 else
         echo "Model size not supported."
         exit 1

--- a/examples/llama/train_llama3.sh
+++ b/examples/llama/train_llama3.sh
@@ -88,7 +88,7 @@ TOKENIZER_MODEL=meta-llama/Llama-3.1-8B
 
 DATA_PATH=${DATA_PATH:-"$DATA_DIR/bookcorpus_text_sentence"}
 
-MAX_POSITION_EMBEDDINGS=128000
+MAX_POSITION_EMBEDDINGS=131072
 
 DEFAULT_LOG_DIR="${EXPERIMENT_DIR}/${NNODES}nodes_rank${NODE_RANK}_train_${MODEL_SIZE}B_mbs${MBS}_bs${BS}_tp${TP}_pp${PP}_cp${CP}_iter${TOTAL_ITERS}/TE_FP8_${TE_FP8}/${TIME_STAMP}"
 LOG_DIR="${LOG_DIR:-${DEFAULT_LOG_DIR}}"
@@ -114,7 +114,8 @@ if [[ $MODEL_SIZE -eq 8 ]]; then #llama2-7B
         NUM_LAYERS=32 # e.g. llama-13b: 40
         NUM_HEADS=32 # e.g. llama-13b: 40
         SEQ_LENGTH=$SEQ_LENGTH
-        NUM_KV_HEADS=8 # llama2 70B uses GQA
+        NUM_KV_HEADS=8 
+        MAX_POSITION_EMBEDDINGS=$MAX_POSITION_EMBEDDINGS
 elif [[ $MODEL_SIZE -eq 70 ]]; then
         HIDDEN_SIZE=8192 # e.g. llama-13b: 5120
         FFN_HIDDEN_SIZE=28672 # e.g. llama-13b: 13824

--- a/examples/llama/train_llama3.sh
+++ b/examples/llama/train_llama3.sh
@@ -113,15 +113,13 @@ if [[ $MODEL_SIZE -eq 8 ]]; then #llama2-7B
         FFN_HIDDEN_SIZE=14336 # e.g. llama-13b: 13824
         NUM_LAYERS=32 # e.g. llama-13b: 40
         NUM_HEADS=32 # e.g. llama-13b: 40
-        SEQ_LENGTH=$SEQ_LENGTH
         NUM_KV_HEADS=8 
 elif [[ $MODEL_SIZE -eq 70 ]]; then
         HIDDEN_SIZE=8192 # e.g. llama-13b: 5120
         FFN_HIDDEN_SIZE=28672 # e.g. llama-13b: 13824
         NUM_LAYERS=80 # e.g. llama-13b: 40
         NUM_HEADS=64 # e.g. llama-13b: 40
-        NUM_KV_HEADS=8 # llama3 70B uses GQA
-        SEQ_LENGTH=$SEQ_LENGTH  
+        NUM_KV_HEADS=8 # llama3 70B uses GQA 
 else
         echo "Model size not supported."
         exit 1


### PR DESCRIPTION
Corrected the configuration for llam2-7b in train_llama2.sh.

The old configuration were different from what mentioned in Original llama2 and on [Huggingface](https://huggingface.co/meta-llama/Llama-2-7b-hf/blob/main/config.json).

Modified changes:

FFN_HIDDEN_SIZE = 11008
NUM_KV_HEADS = 32 
