### PR TITLE
fix Dockerfiles for ROCm

### DIFF
--- a/Dockerfile_rocm.ci
+++ b/Dockerfile_rocm.ci
@@ -66,6 +66,12 @@ RUN git clone https://github.com/caaatch22/grouped_gemm.git &&\
     git submodule update --init --recursive &&\
     pip install .
 
+RUN git clone https://github.com/ROCm/flash-attention/ -b v2.7.3-cktile && \
+    cd flash-attention && \
+    GPU_ARCHS=${PYTORCH_ROCM_ARCH_OVERRIDE} python setup.py install && \
+    cd .. &&\
+    rm -rf flash-attention
+
 WORKDIR $WORKSPACE_DIR
 COPY . Megatron-LM
 WORKDIR $WORKSPACE_DIR/Megatron-LM

--- a/Dockerfile_rocm.dev
+++ b/Dockerfile_rocm.dev
@@ -65,6 +65,12 @@ RUN git clone https://github.com/caaatch22/grouped_gemm.git &&\
     git submodule update --init --recursive &&\
     pip install .
 
+RUN git clone https://github.com/ROCm/flash-attention/ -b v2.7.3-cktile && \
+    cd flash-attention && \
+    GPU_ARCHS=${PYTORCH_ROCM_ARCH_OVERRIDE} python setup.py install && \
+    cd .. &&\
+    rm -rf flash-attention
+
 WORKDIR $WORKSPACE_DIR
 RUN git clone https://github.com/ROCm/Megatron-LM.git Megatron-LM &&\
     cd Megatron-LM &&\


### PR DESCRIPTION
The Dockerfiles for CI and Dev miss flash attention, and the images won't run without the flash attention.