### PR TITLE
fix: set qkv_bias, --no-gradient-accumulation-fusion, and spawn as a MP start method to enable Mixtral 8x7B HuggingFace checkpoint conversion

### DIFF
--- a/tools/checkpoint/convert.py
+++ b/tools/checkpoint/convert.py
@@ -137,6 +137,7 @@ def main():
 
     args = parser.parse_args()
 
+    mp.set_start_method('spawn')
     queue = mp.Queue(maxsize=args.max_queue_size)
 
     print("Starting saver...")

--- a/tools/checkpoint/loader_mixtral_hf.py
+++ b/tools/checkpoint/loader_mixtral_hf.py
@@ -186,6 +186,7 @@ def _load_checkpoint(queue, args):
                 '--no-save-optim',
                 '--no-save-rng',
                 '--no-initialization',
+                '--no-gradient-accumulation-fusion', # Gradient accumulation fusion requires NVIDIA/apex. TODO: remove this line when we have apex working on ROCm platform.
                 '--mock-data', # To pass the "blend data checks" in arguments.py
                 '--transformer-impl', 'transformer_engine',
                 '--load', args.load_dir,
@@ -255,6 +256,7 @@ def _load_checkpoint(queue, args):
     md.output_layer = margs.untie_embeddings_and_output_weights
     md.position_embedding_type = margs.position_embedding_type
     md.linear_bias = margs.add_bias_linear
+    md.qkv_bias = margs.add_qkv_bias
     md.norm_has_bias = False
     md.swiglu = margs.swiglu
     md.previous_tensor_parallel_size = margs.tensor_model_parallel_size


### PR DESCRIPTION
`saver_mcore.py` expects `qkv_bias` model attribute [[1](https://github.com/ROCm/Megatron-LM/blob/rocm_dev/tools/checkpoint/saver_mcore.py#L382-L383)], [[2](https://github.com/ROCm/Megatron-LM/blob/rocm_dev/tools/checkpoint/saver_mcore.py#L417-L420)] but `loader_mixtral_ht.py` doesn't set it. Other loaders do: [loader_mcore.py](https://github.com/ROCm/Megatron-LM/blob/rocm_dev/tools/checkpoint/loader_mcore.py#L234), [loader_megatron.py](https://github.com/ROCm/Megatron-LM/blob/rocm_dev/tools/checkpoint/loader_megatron.py#L222) etc.