### PR TITLE
ltsabadz/fix dist checkpoint loading fsdp

### DIFF
--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -704,7 +704,7 @@ def fix_query_key_value_ordering(model, checkpoint_version):
                      " checkpoint version {}".format(checkpoint_version))
 
 
-def fix_fc1_grouped_deinterleave(model, N_GPUS, checkpoint_name):
+def fix_fc1_grouped_deinterleave(model, data_parallel_size, checkpoint_name):
     """Deinterleave MLP.linear_fc1 tensor chunks if loading distributed checkpoint"""
     if isinstance(model, list):
         assert len(model) == 1
@@ -713,29 +713,31 @@ def fix_fc1_grouped_deinterleave(model, N_GPUS, checkpoint_name):
     # Determine ckpt rank
     distckpt_files = [f for f in os.listdir(checkpoint_name) if f.endswith("distcp")]
     checkpoint_rank = len(distckpt_files)
-    N_groups = max(N_GPUS,checkpoint_rank)
+    n_groups = max(data_parallel_size, checkpoint_rank)
 
-    def grouped_deinterleave_tensor(fc1_weights, N_groups):
-        fc1_weights = fc1_weights.view(N_groups, -1, fc1_weights.shape[1])
-        group_size = fc1_weights.shape[0] // N_GPUS
+    def grouped_deinterleave_tensor(fc1_weights, n_groups):
+        fc1_weights = fc1_weights.view(n_groups, -1, fc1_weights.shape[1])
+        group_size = fc1_weights.shape[0] // data_parallel_size
         result = []
 
-        for i in range(N_GPUS):
-            group = fc1_weights[i * group_size:(i + 1) * group_size]
+        for i in range(data_parallel_size):
+            group = fc1_weights[i * group_size : (i + 1) * group_size]
             mid = group.shape[0] // 2
             reordered = torch.empty_like(group)
             reordered[::2] = group[:mid]
             reordered[1::2] = group[mid:]
             result.append(reordered)
-
         return torch.cat(result, dim=0).view(-1, 1024)
 
     for name, param in model.named_parameters():
-        if any(name.endswith(f'decoder.layers.{i}.mlp.linear_fc1.weight') for i in range(24)):
-            fixed_param = grouped_deinterleave_tensor(param.data, N_groups)
+        if any(
+            name.endswith(f"decoder.layers.{i}.mlp.linear_fc1.weight")
+            for i in range(24)
+        ):
+            fixed_param = grouped_deinterleave_tensor(param.data, n_groups)
             param.data.copy_(fixed_param)
-
     print_rank_0("Successfully applied grouped deinterleave tensor transformation.")
+
 
 def _get_non_persistent_iteration(non_persistent_global_dir, args, checkpointing_context=None):
     if args.non_persistent_ckpt_type is None:


### PR DESCRIPTION
### Problem Description:
Trained a model using FSDP on 8 GPUs, the loss decreases to ~ 2.
Saved the model as a distributed checkpoint.
Resumed pretraining from the checkpoint on 8 GPUs, and the starting loss was consistent with where the previous checkpoint stopped. ✅

If we try to continue pretraining or load model for inference using different number of GPUs model is loaded incorrectly. (loss goes ~ 10 / model outputs gibberish text). And loading logic differs as number of GPUs change. ❌

#### Findings
To diagnose the issue, I loaded the model with 1, 2, and 4 GPUs, called full_tensor() for each layer, and compared the state_dicts with a model loaded on 8 GPUs. All weights were loaded correctly except for `decoder.layers.LAYER_NUM.mlp.linear_fc1.weight`.
Let's say shape of the fc1 layer was 8192x1024. In case of checkpoint trained on 8 GPUs each rank is responsible of 1024x1024 tensors. Each rank splits tensors again in two parts so 16 shards of dimension 512x1024 saved for each fc1 layer.
 
#### Loading Pattern 
There is a pattern on how these tensors are loaded and it depends on number of GPUs you are trying to load on. For each fc1 layer those 512x1024 chunks are concatenated incorrectly. Here is an observed chunk ordering where ID represents it's correct location:
1 GPU   [0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15] 
2 GPUs [0, 2, 4, 6, 1, 3, 5, 7, 8, 10, 12, 14, 9, 11, 13, 15] 
4 GPUs [0, 2, 1, 3, 4, 6, 5, 7, 8, 10, 9, 11, 12, 14, 13, 15]
 
So, for 1 GPU first you concatenate even chunks then odd ones.
For 2 GPUs, you do that for first half of the tensors, then the other one.
For 4 GPUs, for first quarter, then the second quarter, etc.
For 8 GPUs same logic gives correct ordering.
 
#### Current Fix
Iterate on mlp.linear_fc1 layers, reshape to` checkpoint rank x -1 x fc1.shape[1]`. In the case I described it would be `16 x -1 x 1024`.
From 16 chunks, create groups of 16 / n_gpus you are trying to load on.
Deinterleave group.
Reassemble the layer.

#### Tests
This was tested on following scenarios:
Trained model on 2 and 8 GPUs using FSDPv2, saved as distributed checkpoint and loaded on 1-8 GPUs on a single node.
![image](https://github.com/user-attachments/assets/d125345c-9950-4de5-8407-52be030bd40b)

#### Note
This function needs further testing on multi node setup once TW nodes are back. Also, we have observed that the same problem arises when we try to load model converted from hf checkpoint using FSDPv2. The same logic may apply there. Need to test that also. 
This is probably a temporary fix. Ideally we would apply the fix to the place where global_offset for each local tensor gets incorrect value in metadata or while loading sharded_state_dict, that can be included in further investigation on this issue.




































































