### PR TITLE
fix: enable MoE models conversion

### DIFF
--- a/tools/checkpoint/saver_mcore.py
+++ b/tools/checkpoint/saver_mcore.py
@@ -401,10 +401,12 @@ def save_checkpoint(queue, args):
                         "mlp_norm_weight" : post_norm_weight
                     }
                     if margs.num_experts:
-                        params_dict.update({
-                            "mlp_fc1_weight" : mlp_l0_weight[ep_rank][tp_rank],
-                            "mlp_fc2_weight" : mlp_l1_weight[ep_rank][tp_rank]
-                        })
+                        num_local_experts = args.target_expert_parallel_size // margs.num_experts
+                        for expert_idx in range(num_local_experts):
+                            params_dict.update({
+                                f"mlp_fc1_weight.{expert_idx}" : mlp_l0_weight[ep_rank][tp_rank][expert_idx],
+                                f"mlp_fc2_weight.{expert_idx}" : mlp_l1_weight[ep_rank][tp_rank][expert_idx]
+                            })
                     else:
                         params_dict.update({
                             "mlp_fc1_weight" : mlp_l0_weight[tp_rank],


### PR DESCRIPTION
Upstream introduced [model schemas](https://github.com/NVIDIA/Megatron-LM/commit/0be5646cc55a796d48aaabbc9cfef1c1ff4f8084) for model conversion. 
`MCoreMoETESchema` expects expert [layers with local expert index](https://github.com/NVIDIA/Megatron-LM/commit/0be5646cc55a796d48aaabbc9cfef1c1ff4f8084#diff-4a68c8bd3c583dccef833cc3645cac1bac0b029edc1f45190ebda7a9f2996f80R123-R124). Unfortunately `saver_mcore.py` doesn't use local expert index. That causes MoE layers to be filled with zeros.

The PR fixes that.