### PR TITLE
fix: allow interleaved schedule for PP2

### DIFF
--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -386,10 +386,6 @@ def validate_args(args, defaults={}):
                 'pipeline-model-parallel size should be greater than 2 to avoid having multiple '\
                 'p2p sends and recvs between same 2 ranks per communication batch'
         
-        assert args.pipeline_model_parallel_size > 2, \
-            'pipeline-model-parallel size should be greater than 2 with ' \
-            'interleaved schedule'
-        
         assert args.num_layers is not None
         # Double check divisibility check here since check above is if guarded.
         assert args.num_layers % args.transformer_pipeline_model_parallel_size == 0, \


### PR DESCRIPTION
https://github.com/ROCm/Megatron-LM/commit/915fb3bbed06f3e57963411fd7fdf3b05d3aaf1f introduced regression/duplication. Compare [the upstream](https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/training/arguments.py#L346-L354) with [our version](https://github.com/ROCm/Megatron-LM/blob/rocm_dev/megatron/training/arguments.py#L379-L391)