### PR TITLE
Adding CMD line argument support for llama

### DIFF
--- a/examples/llama/train_llama2.sh
+++ b/examples/llama/train_llama2.sh
@@ -10,7 +10,7 @@
 export GPU_MAX_HW_QUEUES=2
 export TORCH_NCCL_HIGH_PRIORITY=1
 export NCCL_CHECKS_DISABLE=1
-export NCCL_IB_HCA="${NCCL_IB_HCA:-rdma0,rdma1,rdma2,rdma3,rdma4,rdma5,rdma6,rdma7} 
+export NCCL_IB_HCA="${NCCL_IB_HCA:-rdma0,rdma1,rdma2,rdma3,rdma4,rdma5,rdma6,rdma7}" 
 export NCCL_IB_GID_INDEX=3
 export NCCL_CROSS_NIC=0
 export CUDA_DEVICE_MAX_CONNECTIONS=1

--- a/examples/llama/train_llama2.sh
+++ b/examples/llama/train_llama2.sh
@@ -10,7 +10,7 @@
 export GPU_MAX_HW_QUEUES=2
 export TORCH_NCCL_HIGH_PRIORITY=1
 export NCCL_CHECKS_DISABLE=1
-export NCCL_IB_HCA=rdma0,rdma1,rdma2,rdma3,rdma4,rdma5,rdma6,rdma7 
+export NCCL_IB_HCA="${NCCL_IB_HCA:-rdma0,rdma1,rdma2,rdma3,rdma4,rdma5,rdma6,rdma7} 
 export NCCL_IB_GID_INDEX=3
 export NCCL_CROSS_NIC=0
 export CUDA_DEVICE_MAX_CONNECTIONS=1
@@ -233,7 +233,7 @@ DATA_ARGS="
 "
 
 # For multi-node runs DATA_CACHE_PATH should point to a common path accessible by all the nodes (for eg, an NFS directory)
-DATA_CACHE_PATH="/home/cache"
+DATA_CACHE_PATH="${DATA_CACHE_PATH:-/home/cache}"
 
 if [ "$MOCK_DATA" -eq 1 ];then
     DATA_ARGS="$DATA_ARGS --mock-data --data-cache-path $DATA_CACHE_PATH"

--- a/examples/llama/train_llama3.sh
+++ b/examples/llama/train_llama3.sh
@@ -10,7 +10,7 @@
 export GPU_MAX_HW_QUEUES=2
 export TORCH_NCCL_HIGH_PRIORITY=1
 export NCCL_CHECKS_DISABLE=1
-export NCCL_IB_HCA=rdma0,rdma1,rdma2,rdma3,rdma4,rdma5,rdma6,rdma7 
+export NCCL_IB_HCA="${NCCL_IB_HCA:-rdma0,rdma1,rdma2,rdma3,rdma4,rdma5,rdma6,rdma7}"
 export NCCL_IB_GID_INDEX=3
 export NCCL_CROSS_NIC=0
 export CUDA_DEVICE_MAX_CONNECTIONS=1
@@ -223,7 +223,7 @@ DATA_ARGS="
     --num-workers $ds_works \
 "
 # For multi-node runs DATA_CACHE_PATH should point to a common path accessible by all the nodes (for eg, an NFS directory)
-DATA_CACHE_PATH="/home/cache"
+DATA_CACHE_PATH="${DATA_CACHE_PATH:-/home/cache}"
 
 if [ "$MOCK_DATA" -eq 1 ];then
     DATA_ARGS="$DATA_ARGS --mock-data --data-cache-path $DATA_CACHE_PATH"


### PR DESCRIPTION
This PR is adding command line argument support for `NCCL_IB_HCA` and `DATA_CACHE_PATH` variable. 

Currently, these variables are fixed in training scripts and requires users to edit training scripts. In this PR, we are adding support to pass them as command line argument, through which users can override the default values in the training scripts.