### PR TITLE
[Fix] LayerNorm and RMSNorm not compatible on TE 1.13

### DIFF
--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -68,7 +68,7 @@ class TENorm:
     def __new__(cls, config: TransformerConfig, hidden_size: int, eps: float = 1e-5):
         if config.normalization == "LayerNorm":
             instance = te.pytorch.LayerNorm(
-                hidden_size=hidden_size,
+                hidden_size,
                 eps=eps,
                 sequence_parallel=config.sequence_parallel,
                 zero_centered_gamma=config.layernorm_zero_centered_gamma,
@@ -79,7 +79,7 @@ class TENorm:
                 te.pytorch, "RMSNorm"
             ), "Transformer-Engine >= v0.11 required to use this feature"
             instance = te.pytorch.RMSNorm(
-                hidden_size=hidden_size,
+                hidden_size,
                 eps=eps,
                 sequence_parallel=config.sequence_parallel,
                 zero_centered_gamma=config.layernorm_zero_centered_gamma,


### PR DESCRIPTION
On ROCm TE 1.13 the LayerNorm and RMSNorm module have changed the name of first argument from hidden_size to normalized_shape (More details: https://github.com/ROCm/TransformerEngine/blob/1c1299a9713af7de82ba93cd648800e67d024784/transformer_engine/pytorch/module/layernorm.py#L31-L32).
We need to make sure Megatron-LM is compatible with TE 1.13.