### PR TITLE
Fix non-convergence observed when rope-fusion is enabled during training.

### DIFF
--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -740,7 +740,12 @@ class TEDotProductAttention(te.pytorch.DotProductAttention):
         # WAR for peak memory usage.
         # See https://gitlab-master.nvidia.com/ADLR/megatron-lm/-/merge_requests/2388
         if self.config.apply_rope_fusion and qkv_format == 'bshd':
-            query, key, value = [x.contiguous().transpose(0, 1) for x in (query, key, value)]
+            # In PyTorch, operations like transpose create a view of the original tensor.
+            # Taking a view of a tensor (through a transpose operation) that is contiguous in memory
+            # could potentially produce a tensor which is non-contiguous in memory leading to performance impacts.
+            # To eliminate this possibility, we apply transpose operation followed by contiguous()
+            # to ensure that the resulting tensor is contiguous in memory.
+            query, key, value = [x.transpose(0, 1).contiguous() for x in (query, key, value)]                
             # In PyTorch, the following two tensors are in fact the same:
             #   Tensor with shape (1, S, H, D) and stride (S*H*D, H*D, D, 1)
             #   Tensor with shape (1, S, H, D) and stride (H*D, H*D, D, 1)


### PR DESCRIPTION
### Background

When rope-fusion is enabled during the training non-convergence in loss curve is observed. See here

![image](https://github.com/user-attachments/assets/e75732d1-2180-48f5-a909-69b807233b20)


Greenish curve is obtained when rope-fusion is enabled and orange curve is obtained when rope-fusion is disabled. Greenish curve plateaus earlier.

Reproduction of this issue can be made following the instructions [here](https://github.com/AMD-AIG-AIMA/model-tooling/tree/main/llm/rope-fusion-debugging).

### Root cause

When rope-fusion is enabled (`config.apply_rope_fusion = True`), the code for the Scaled dot product attention (SDPA) implemented  in TE (Transformer engine) is called through the transformer engine wrapper for Megatron-LM (see code [here](https://github.com/ROCm/Megatron-LM/blob/f612bdf4a27c25309ad64766ca3c47c7eb33eb70/megatron/core/extensions/transformer_engine.py#L742)). In the same section of code at line # 743, there is a contiguous operation is applied on q, k, and v tensors which is followed by a transpose operation.

Now, according to PyTorch [documentation](https://docs.pytorch.org/docs/stable/tensor_view.html) the operations like transpose creates a view of the original tensor which might not be contiguous in memory. This lack of contiguity in memory can cause performance issues. 

To investigate further, we took help from this Nvidia [fix](https://github.com/NVIDIA/Megatron-LM/commit/7bb53792831d80007789ff5c60bc1798cbd34548). This fix is not synced into ROCm/Megatron-LM yet. We do not have access to the issue against which this PR was submitted but the code changes does essentially two things:

1.  Changes the sequence of operation on the tensor from `contiguous followed by transpose` to `transpose followed by contiguous`. So,

```
 query, key, value = [x.contiguous().transpose(0, 1) for x in (query, key, value)]

```
is changed to 

```
 query, key, value = [x.transpose(0, 1).contiguous() for x in (query, key, value)]

```
This ensures that output q, k, and v tensors are contiguous in memory.

2. It prioritizes calling `Nvidia/Apex`'s FusedRope implementation against TE's FusedRope implementation.


We did some experiments to see what happens if we only made the code changes highlighted in 1. 

![image](https://github.com/user-attachments/assets/4d066cc8-d18a-47d1-8783-b2428441d75b)



After fixing the code, when we checked the loss curve with rope-fusion enabled  (RF_ENA) and rope-fusion disabled (RF_DIS) we get identical loss curve without non-convergence. This indicates that this non-convergence (when rope-fusion enabled) can be resolved by fixing the order of operations.

### Fix

The fix for this issue is to correct the order of operations applied on tensor so that the output tensor remains contiguous in memory.

```
 # In PyTorch, operations like transpose create a view of the original tensor.
 # Taking a view of a tensor (through a transpose operation) that is contiguous in memory
 # could potentially produce a tensor which is non-contiguous in memory leading to performance impacts.
 # To eliminate this possibility, we apply transpose operation followed by contiguous()
 # to ensure that the resulting tensor is contiguous in memory.
 
 query, key, value = [x.transpose(0, 1).contiguous() for x in (query, key, value)] 


```

### Notes

1. Referenced [fix](https://github.com/NVIDIA/Megatron-LM/commit/7bb53792831d80007789ff5c60bc1798cbd34548) from Nvidia preferences Apex to TE for implementing Rope-Fusion. We do not have full understanding why this is the case as the issue against which that fix is released is not public. 
2. In the TE extension for Megatron-LM (Megatron-LM/megatron/core/extensions/transformer_engine.py), there is another class called `TEDotProductAttentionMLA(te.pytorch.DotProductAttention)` which at [line](https://github.com/ROCm/Megatron-LM/blob/f612bdf4a27c25309ad64766ca3c47c7eb33eb70/megatron/core/extensions/transformer_engine.py#L1315) uses the same code against which we have provided the fix. We have not updated that line as that class is not covered in the scope of this PR.












