### PR TITLE
[Megatron-LM] Fix torch_dist ckpt format saving

### DIFF
--- a/examples/deepseek_v2/train_deepseekv2.sh
+++ b/examples/deepseek_v2/train_deepseekv2.sh
@@ -4,7 +4,7 @@
 #
 # See LICENSE for license information.
 #################################################################################
-set -e
+# set -e
 
 TOKENIZER_MODEL="deepseek-ai/DeepSeek-V2-Lite"
 

--- a/examples/deepseek_v2/train_deepseekv2.sh
+++ b/examples/deepseek_v2/train_deepseekv2.sh
@@ -4,7 +4,7 @@
 #
 # See LICENSE for license information.
 #################################################################################
-# set -e
+set -e
 
 TOKENIZER_MODEL="deepseek-ai/DeepSeek-V2-Lite"
 
@@ -19,8 +19,6 @@ echo $CURRENT_DIR
 export GPU_MAX_HW_QUEUES=${GPU_MAX_HW_QUEUES:-2}
 export TORCH_NCCL_HIGH_PRIORITY=${TORCH_NCCL_HIGH_PRIORITY:-1}
 export NCCL_CHECKS_DISABLE=${NCCL_CHECKS_DISABLE:-1}
-NCCL_IB_HCA_LIST=$(rdma link -j | python3 -c "import sys, json; links=json.load(sys.stdin);names=[links[i]['ifname'] for i in range(8)]; print(*names,sep=',')")
-export NCCL_IB_HCA=${NCCL_IB_HCA:-$NCCL_IB_HCA_LIST}
 export NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX:-3}
 export NCCL_CROSS_NIC=${NCCL_CROSS_NIC:-0}
 export CUDA_DEVICE_MAX_CONNECTIONS=${CUDA_DEVICE_MAX_CONNECTIONS:-1} # Reducing to 1 ensures no PCIE traffic (even on single node)
@@ -124,6 +122,9 @@ if [ "${NNODES:-1}" -gt 1 ]; then
     export NCCL_SOCKET_IFNAME="${NCCL_SOCKET_IFNAME:-ens51np0}"
     export GLOO_SOCKET_IFNAME="${GLOO_SOCKET_IFNAME:-ens51np0}"
     echo "NCCL and GLOO socket interfaces set."
+    NCCL_IB_HCA_LIST=$(rdma link -j | python3 -c "import sys, json; links=json.load(sys.stdin);names=[links[i]['ifname'] for i in range(8)]; print(*names,sep=',')")
+    export NCCL_IB_HCA=${NCCL_IB_HCA:-$NCCL_IB_HCA_LIST}
+    echo "NCCL_IB_HCA set for multinode."
 else
     echo "Single node setup, skipping NCCL and GLOO socket interface settings."
 fi

--- a/examples/deepseek_v3/train_deepseekv3.sh
+++ b/examples/deepseek_v3/train_deepseekv3.sh
@@ -5,7 +5,7 @@
 # See LICENSE for license information.
 #################################################################################
 
-# set -e
+set -e
 
 # exp
 EXPERIMENT="deepseek_v3"
@@ -22,8 +22,6 @@ echo ""
 export GPU_MAX_HW_QUEUES=${GPU_MAX_HW_QUEUES:-2}
 export TORCH_NCCL_HIGH_PRIORITY=${TORCH_NCCL_HIGH_PRIORITY:-1}
 export NCCL_CHECKS_DISABLE=${NCCL_CHECKS_DISABLE:-1}
-NCCL_IB_HCA_LIST=$(rdma link -j | python3 -c "import sys, json; links=json.load(sys.stdin);names=[links[i]['ifname'] for i in range(8)]; print(*names,sep=',')")
-export NCCL_IB_HCA=${NCCL_IB_HCA:-$NCCL_IB_HCA_LIST}
 export NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX:-3}
 export NCCL_CROSS_NIC=${NCCL_CROSS_NIC:-0}
 export CUDA_DEVICE_MAX_CONNECTIONS=${CUDA_DEVICE_MAX_CONNECTIONS:-1} # Reducing to 1 ensures no PCIE traffic (even on single node)
@@ -59,6 +57,9 @@ if [ "${NNODES:-1}" -gt 1 ]; then
     export NCCL_SOCKET_IFNAME="${NCCL_SOCKET_IFNAME:-ens51np0}"
     export GLOO_SOCKET_IFNAME="${GLOO_SOCKET_IFNAME:-ens51np0}"
     echo "NCCL and GLOO socket interfaces set."
+    NCCL_IB_HCA_LIST=$(rdma link -j | python3 -c "import sys, json; links=json.load(sys.stdin);names=[links[i]['ifname'] for i in range(8)]; print(*names,sep=',')")
+    export NCCL_IB_HCA=${NCCL_IB_HCA:-$NCCL_IB_HCA_LIST}
+    echo "NCCL_IB_HCA set for multinode."
 else
     echo "Single node setup, skipping NCCL and GLOO socket interface settings."
 fi

--- a/examples/deepseek_v3/train_deepseekv3.sh
+++ b/examples/deepseek_v3/train_deepseekv3.sh
@@ -5,7 +5,7 @@
 # See LICENSE for license information.
 #################################################################################
 
-set -e
+# set -e
 
 # exp
 EXPERIMENT="deepseek_v3"

--- a/megatron/core/dist_checkpointing/strategies/filesystem_async.py
+++ b/megatron/core/dist_checkpointing/strategies/filesystem_async.py
@@ -23,7 +23,7 @@ from torch.futures import Future
 try:
     # This PR https://github.com/pytorch/pytorch/pull/143359 introduced breaking change to saving checkpoints 
     # in torch_dist format. This is a workaround to fix the issue.
-    from torch.distributed.checkpoint.filesystem import _StorageWriterTransforms, SerializationFormat
+    from torch.distributed.checkpoint.filesystem import _StorageWriterTransforms
     from functools import partial
     import inspect
     if "serialization_format" in inspect.signature(_write_item).parameters:

--- a/megatron/core/dist_checkpointing/strategies/filesystem_async.py
+++ b/megatron/core/dist_checkpointing/strategies/filesystem_async.py
@@ -23,9 +23,9 @@ from torch.futures import Future
 try:
     # This PR https://github.com/pytorch/pytorch/pull/143359 introduced breaking change to saving checkpoints 
     # in torch_dist format. This is a workaround to fix the issue.
-    from torch.distributed.checkpoint.filesystem import _StorageWriterTransforms
+    from torch.distributed.checkpoint.filesystem import _StorageWriterTransforms, SerializationFormat
     from functools import partial
-    _write_item = partial(_write_item, _StorageWriterTransforms())
+    _write_item = partial(_write_item, _StorageWriterTransforms(), serialization_format=SerializationFormat.TORCH_SAVE)
 except ImportError:
     pass
 

--- a/megatron/core/dist_checkpointing/strategies/filesystem_async.py
+++ b/megatron/core/dist_checkpointing/strategies/filesystem_async.py
@@ -25,7 +25,12 @@ try:
     # in torch_dist format. This is a workaround to fix the issue.
     from torch.distributed.checkpoint.filesystem import _StorageWriterTransforms, SerializationFormat
     from functools import partial
-    _write_item = partial(_write_item, _StorageWriterTransforms(), serialization_format=SerializationFormat.TORCH_SAVE)
+    import inspect
+    if "serialization_format" in inspect.signature(_write_item).parameters:
+         from torch.distributed.checkpoint.filesystem import SerializationFormat
+         _write_item = partial(_write_item, _StorageWriterTransforms(), serialization_format=SerializationFormat.TORCH_SAVE)
+    else:
+        _write_item = partial(_write_item, _StorageWriterTransforms())
 except ImportError:
     pass
 


### PR DESCRIPTION
Problem: Checkpoint saving is erroring out for torch_dist format because of a missing serialization_format argument, which was introduced recently in upstream [pytorch](https://github.com/pytorch/pytorch/blob/a6210fd07b8fe1924f24229bb30562608af4f41a/torch/distributed/checkpoint/filesystem.py#L313). 

Error:
`[rank4]:   File "/workspace/Megatron-LM/megatron/core/dist_checkpointing/strategies/torch.py", line 706, in finalize_fn
[rank4]:     save_state_dict_async_finalize(*save_state_dict_ret)
[rank4]:   File "/workspace/Megatron-LM/megatron/core/dist_checkpointing/strategies/state_dict_saver.py", line 144, in save_state_dict_async_finalize
[rank4]:     write_results = storage_writer.retrieve_write_results()
[rank4]:   File "/workspace/Megatron-LM/megatron/core/dist_checkpointing/strategies/filesystem_async.py", line 337, in retrieve_write_results
[rank4]:     raise RuntimeError(f'Worker failure: {write_results_or_exc}') from write_results_or_exc
[rank4]: RuntimeError: Worker failure: _write_item() missing 1 required positional argument: 'serialization_format'
[rank5]: TypeError: _write_item() missing 1 required positional argument: 'serialization_format'`

Solution: Add serialization_format argument in `_write_item()`