### PR TITLE
[BUG]  Guard parallelism check under MoE specific checks. 

### DIFF
--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -710,9 +710,9 @@ def validate_args(args, defaults={}):
     if args.num_experts is not None:
         assert args.spec is None, "Model Spec must be None when using MoEs"
     
-    if args.tensor_model_parallel_size > 1:
-            assert args.sequence_parallel, \
-                "When using MoE and tensor parallelism, sequence parallelism must be used."
+        if args.tensor_model_parallel_size > 1:
+                assert args.sequence_parallel, \
+                    "When using MoE and tensor parallelism, sequence parallelism must be used."
                 
     if args.moe_ffn_hidden_size is None:
         args.moe_ffn_hidden_size = args.ffn_hidden_size


### PR DESCRIPTION
### Issue
The parallel configuration assertion in [megatron/traininig/arguments.py](https://github.com/ROCm/Megatron-LM/blob/38fc8307d502acea8006ca995f81b4c3a37f516d/megatron/training/arguments.py#L713-L715)  gets triggered even if we aren't running an MoE model here, leading to - 
```
...
  File "/workspace/Megatron-LM/megatron/training/arguments.py", line 714, in validate_args
    assert args.sequence_parallel, \
AssertionError: When using MoE and tensor parallelism, sequence parallelism must be used.
``` 

### Reproduce the bug
Follow instructions to run llama3 training and enable tensor parallelism (`TP=2` or higher) like - 
``` 
TEE_OUTPUT=1  TP=2  SEQ_PARALLEL=0  MODEL_SIZE=8  bash examples/llama/train_llama3.sh
```

### Fix
This PR ensures the check is performed only when the condition - `args.num_experts is not None` - is met. 


