### PR TITLE
FP8 Weight Transpose Cache ON/OFF

### DIFF
--- a/examples/llama/train_llama2.sh
+++ b/examples/llama/train_llama2.sh
@@ -316,6 +316,10 @@ EXTRA_ARGS="$EXTRA_ARGS --transformer-impl=transformer_engine \
     --fp8-amax-compute-algo=max \
     --attention-softmax-in-fp32 \
 "
+    if [ "$FSDP" -eq 1 ]; then
+        EXTRA_ARGS="$EXTRA_ARGS --keep_fp8_weight_transpose_cache" 
+    fi
+    
 fi
 
 if [ -n "${WANDB_API_KEY}" ]; then

--- a/examples/llama/train_llama3.sh
+++ b/examples/llama/train_llama3.sh
@@ -298,6 +298,9 @@ if [ "$TE_FP8" -eq 1 ]; then
         --fp8-amax-compute-algo=max \
         --attention-softmax-in-fp32 \
 "
+    if [ "$FSDP" -eq 1 ]; then
+        EXTRA_ARGS="$EXTRA_ARGS --keep_fp8_weight_transpose_cache" 
+    fi
 fi
 
 if [ -n "${WANDB_API_KEY}" ]; then

--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -214,6 +214,10 @@ class TELinear(te.pytorch.Linear):
                 tp_size = 1
                 tp_group = None
 
+        if is_te_min_version("2.2.0"):
+            assert hasattr(te.pytorch.Linear, "keep_fp8_weight_transpose_cache"), "Transformer Engine v2.2.0 or later is required to use keep_fp8_weight_transpose_cache"
+            extra_kwargs["keep_fp8_weight_transpose_cache"] = self.config.keep_fp8_weight_transpose_cache
+
         super().__init__(
             in_features=input_size,
             out_features=output_size,
@@ -343,6 +347,10 @@ class TELayerNormColumnParallelLinear(te.pytorch.LayerNormLinear):
                         tp_comm_buffer_name is not None
                     ), "Buffer name should be set to configure communication overlap settings"
                     extra_kwargs["ub_name"] = tp_comm_buffer_name
+
+        if is_te_min_version("2.2.0"):
+            assert hasattr(te.pytorch.Linear, "keep_fp8_weight_transpose_cache"), "Transformer Engine v2.2.0 or later is required to use keep_fp8_weight_transpose_cache"
+            extra_kwargs["keep_fp8_weight_transpose_cache"] = self.config.keep_fp8_weight_transpose_cache
 
         super().__init__(
             in_features=input_size,

--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -223,7 +223,7 @@ class TELinear(te.pytorch.Linear):
                 tp_size = 1
                 tp_group = None
 
-        if is_te_min_version("2.2.0"):
+        if is_te_min_version("2.2.0.dev0"):
             assert class_has_init_param(te.pytorch.Linear, "keep_fp8_weight_transpose_cache"), "Transformer Engine v2.2.0 or later is required to use keep_fp8_weight_transpose_cache"
             extra_kwargs["keep_fp8_weight_transpose_cache"] = self.config.keep_fp8_weight_transpose_cache
 
@@ -357,7 +357,7 @@ class TELayerNormColumnParallelLinear(te.pytorch.LayerNormLinear):
                     ), "Buffer name should be set to configure communication overlap settings"
                     extra_kwargs["ub_name"] = tp_comm_buffer_name
 
-        if is_te_min_version("2.2.0"):
+        if is_te_min_version("2.2.0.dev0"):
             assert class_has_init_param(te.pytorch.Linear, "keep_fp8_weight_transpose_cache"), "Transformer Engine v2.2.0 or later is required to use keep_fp8_weight_transpose_cache"
             extra_kwargs["keep_fp8_weight_transpose_cache"] = self.config.keep_fp8_weight_transpose_cache
 

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -420,6 +420,9 @@ class TransformerConfig(ModelParallelConfig):
     flash_decode: bool = False
     """ Use the optimized flash decoding kernel during inference. """
 
+    keep_fp8_weight_transpose_cache: bool = False
+    """Don't cache the FP8 weight transposes to save memory"""
+
     def __post_init__(self):
         """Python dataclass method that is used to modify attributes after initialization.
         See https://docs.python.org/3/library/dataclasses.html#post-init-processing for more

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -901,6 +901,10 @@ def _add_transformer_engine_args(parser):
     group.add_argument('--fp8-param-gather', action='store_true',
                        help='Keep the compute param in fp8 (do not use any other intermediate '
                             'dtype) and perform the param all-gather in fp8.')
+    group.add_argument('--keep_fp8_weight_transpose_cache', action='store_true', 
+                       help='Keep the fp8 weight transpose cache in memory to avoid recomputing it '
+                            ' This will use more memory')
+
     return parser
 
 def _add_inference_args(parser):


### PR DESCRIPTION
1. adds a `keep_fp8_weight_transpose_cache` argument that integrates into Transformer Engine extensions. 
2. Control transpose memory allocation during checkpoint loading as well as runtime. 
3. Applied to only `te version >= 2.2.0.dev0`
4. Corresponding TE PR: https://github.com/ROCm/TransformerEngine/pull/248