### PR TITLE
added rop fusion fix for newer versions of TE

### DIFF
--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -1,12 +1,12 @@
 # Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
 
 import dataclasses
+import inspect
 import io
 import os
 import pickle
 import warnings
 from typing import Any, Callable, Optional
-import inspect
 
 import torch
 import transformer_engine as te
@@ -14,8 +14,8 @@ from packaging.version import Version as PkgVersion
 from torch import Tensor
 from torch.nn.parameter import Parameter
 
-from megatron.core.model_parallel_config import ModelParallelConfig
 from megatron.core.dist_checkpointing.utils import replace_prefix_for_sharding
+from megatron.core.model_parallel_config import ModelParallelConfig
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.parallel_state import (
     get_context_parallel_global_ranks,
@@ -37,7 +37,6 @@ from megatron.core.tensor_parallel.layers import (
     set_tensor_model_parallel_attributes,
 )
 from megatron.core.tensor_parallel.random import get_data_parallel_rng_tracker_name
-
 from megatron.core.tensor_parallel.utils import divide
 from megatron.core.transformer.enums import AttnMaskType
 from megatron.core.transformer.transformer_config import TransformerConfig
@@ -109,7 +108,7 @@ class TELinear(te.pytorch.Linear):
     Note that if Megatron's parallel_state has not been initialized
     yet, the tp_group passed to TE will be None and must be set later
     via set_tensor_parallel_group().
-    
+
     parallel_mode currently supports 3 different values:
         - "column": Split the weight matrix along output dimension (used in TEColumnParallelLinear)
         - "row": Split the weight matrix along input dimension (used in TERowParallelLinear)
@@ -224,8 +223,12 @@ class TELinear(te.pytorch.Linear):
                 tp_group = None
 
         if is_te_min_version("2.2.0.dev0"):
-            assert class_has_init_param(te.pytorch.Linear, "keep_fp8_weight_transpose_cache"), "Transformer Engine v2.2.0 or later is required to use keep_fp8_weight_transpose_cache"
-            extra_kwargs["keep_fp8_weight_transpose_cache"] = self.config.keep_fp8_weight_transpose_cache
+            assert class_has_init_param(
+                te.pytorch.Linear, "keep_fp8_weight_transpose_cache"
+            ), "Transformer Engine v2.2.0 or later is required to use keep_fp8_weight_transpose_cache"
+            extra_kwargs["keep_fp8_weight_transpose_cache"] = (
+                self.config.keep_fp8_weight_transpose_cache
+            )
 
         super().__init__(
             in_features=input_size,
@@ -358,8 +361,12 @@ class TELayerNormColumnParallelLinear(te.pytorch.LayerNormLinear):
                     extra_kwargs["ub_name"] = tp_comm_buffer_name
 
         if is_te_min_version("2.2.0.dev0"):
-            assert class_has_init_param(te.pytorch.Linear, "keep_fp8_weight_transpose_cache"), "Transformer Engine v2.2.0 or later is required to use keep_fp8_weight_transpose_cache"
-            extra_kwargs["keep_fp8_weight_transpose_cache"] = self.config.keep_fp8_weight_transpose_cache
+            assert class_has_init_param(
+                te.pytorch.Linear, "keep_fp8_weight_transpose_cache"
+            ), "Transformer Engine v2.2.0 or later is required to use keep_fp8_weight_transpose_cache"
+            extra_kwargs["keep_fp8_weight_transpose_cache"] = (
+                self.config.keep_fp8_weight_transpose_cache
+            )
 
         super().__init__(
             in_features=input_size,
@@ -810,9 +817,7 @@ class TEDotProductAttention(te.pytorch.DotProductAttention):
         # TE with version>=1.9 introduces an extra state in DotProductAttention Module
         if is_te_min_version("1.9.0.dev0") and ('_extra_state' in state_dict):
             state_dict.pop('_extra_state')
-        return make_sharded_tensors_for_checkpoint(
-            state_dict, prefix, {}, sharded_offsets
-        )
+        return make_sharded_tensors_for_checkpoint(state_dict, prefix, {}, sharded_offsets)
 
 
 if is_te_min_version("1.9.0.dev0"):
@@ -1289,7 +1294,10 @@ class TEDotProductAttentionMLA(te.pytorch.DotProductAttention):
 
         super().__init__(
             num_attention_heads=self.config.num_attention_heads,
-            kv_channels=[self.config.kv_channels+self.config.qk_rope_head_dim, self.config.kv_channels],
+            kv_channels=[
+                self.config.kv_channels + self.config.qk_rope_head_dim,
+                self.config.kv_channels,
+            ],
             attention_dropout=(
                 self.config.attention_dropout if attention_dropout is None else attention_dropout
             ),
@@ -1357,13 +1365,7 @@ class TEDotProductAttentionMLA(te.pytorch.DotProductAttention):
                 **packed_seq_kwargs,
             )
         else:
-            core_attn_out = super().forward(
-                query,
-                key,
-                value,
-                attention_mask,
-                **packed_seq_kwargs,
-            )
+            core_attn_out = super().forward(query, key, value, attention_mask, **packed_seq_kwargs)
 
         if self.config.apply_rope_fusion and qkv_format == 'bshd':
             return core_attn_out.transpose(0, 1)
@@ -1470,8 +1472,39 @@ try:
             return FusedRoPEFunc.apply(t, freqs, "thd", cu_seqlens)
 
 except ImportError:
+    # Fallback to apply_rotary_pos_emb for newer TE versions
+    try:
+        from transformer_engine.pytorch.attention import apply_rotary_pos_emb
 
-    pass
+        def fused_apply_rotary_pos_emb(t: torch.Tensor, freqs: torch.Tensor) -> torch.Tensor:
+            """Apply rotary positional embedding to input tensor T in `sbhd` format."""
+            return apply_rotary_pos_emb(t, freqs, tensor_format="sbhd", fused=True)
+
+        def fused_apply_rotary_pos_emb_thd(
+            t: torch.Tensor,
+            cu_seqlens: torch.Tensor,
+            freqs: torch.Tensor,
+            cp_size: int = 1,
+            cp_rank: int = 0,
+        ) -> torch.Tensor:
+            """
+            Apply rotary positional embedding to input tensor T in `thd` format with CP support.
+            """
+            return apply_rotary_pos_emb(
+                t,
+                freqs,
+                tensor_format="thd",
+                fused=True,
+                cu_seqlens=cu_seqlens,
+                cp_size=cp_size,
+                cp_rank=cp_rank,
+            )
+
+    except ImportError:
+        # Don't define the functions at all if neither TE implementation is available
+        # This allows rope_utils.py to fall back to Apex
+        pass
+
 
 try:
 

--- a/megatron/core/models/common/embeddings/rope_utils.py
+++ b/megatron/core/models/common/embeddings/rope_utils.py
@@ -23,7 +23,12 @@ try:
         fused_apply_rotary_pos_emb_thd,
     )
 
-    HAVE_APPLY_ROPE_FUSION = True
+    # Check if they're actually defined (not None)
+    if fused_apply_rotary_pos_emb is not None and fused_apply_rotary_pos_emb_thd is not None:
+        HAVE_APPLY_ROPE_FUSION = True
+    else:
+        raise ImportError("RoPE fusion functions are None, trying Apex fallback")
+
 except ImportError:
     try:
         from apex.transformer.functional import (

--- a/tests/unit_tests/extensions/test_rope_fusion_compatibility.py
+++ b/tests/unit_tests/extensions/test_rope_fusion_compatibility.py
@@ -1,0 +1,84 @@
+from unittest import mock
+
+import pytest
+
+from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+from megatron.core.transformer.transformer_config import TransformerConfig
+from tests.unit_tests.test_utilities import Utils
+
+
+class TestRoPEFusionCompatibility:
+
+    @pytest.fixture(scope='function', autouse=True)
+    def setup_and_teardown(self):
+        Utils.initialize_model_parallel(1, 1)
+        model_parallel_cuda_manual_seed(123)
+        self.transformer_config = TransformerConfig(
+            num_layers=2,
+            add_bias_linear=False,
+            hidden_size=128,
+            num_attention_heads=4,
+            use_cpu_initialization=True,
+        )
+        yield
+        Utils.destroy_model_parallel()
+
+    def test_rope_fusion_with_unavailable_flag(self):
+        """Test error handling when RoPE fusion is unavailable."""
+        with mock.patch(
+            'megatron.core.models.common.embeddings.rope_utils.HAVE_APPLY_ROPE_FUSION', False
+        ):
+            # Should raise error when trying to enable
+            with pytest.raises(ValueError, match="apply_rope_fusion is not available"):
+                TransformerConfig(
+                    num_layers=2,
+                    hidden_size=128,
+                    num_attention_heads=4,
+                    use_cpu_initialization=True,
+                    apply_rope_fusion=True,
+                )
+
+    def test_rope_fusion_with_available_flag(self):
+        """Test that RoPE fusion can be enabled when available."""
+        with mock.patch(
+            'megatron.core.models.common.embeddings.rope_utils.HAVE_APPLY_ROPE_FUSION', True
+        ):
+            config = TransformerConfig(
+                num_layers=2,
+                hidden_size=128,
+                num_attention_heads=4,
+                use_cpu_initialization=True,
+                apply_rope_fusion=True,
+            )
+            assert config.apply_rope_fusion is True
+
+    def test_compatibility_layer_with_new_api(self):
+        """Test that the compatibility fix works with new TE API."""
+        import transformer_engine.pytorch.attention as te_attn
+
+        # Verify expected state: new API present, old API absent
+        if hasattr(te_attn, 'apply_rotary_pos_emb') and not hasattr(te_attn, 'FusedRoPEFunc'):
+            import megatron.core.extensions.transformer_engine as te_ext
+            from megatron.core.models.common.embeddings.rope_utils import HAVE_APPLY_ROPE_FUSION
+
+            # Compatibility layer should provide the functions
+            assert hasattr(te_ext, 'fused_apply_rotary_pos_emb')
+            assert te_ext.fused_apply_rotary_pos_emb is not None
+            assert HAVE_APPLY_ROPE_FUSION is True
+        else:
+            pytest.skip("Test requires new TE API without old API")
+
+    def test_rope_without_fusion(self):
+        """Test that RoPE works without fusion."""
+        from megatron.core.models.common.embeddings.rope_utils import apply_rotary_pos_emb
+
+        assert apply_rotary_pos_emb is not None
+
+        config = TransformerConfig(
+            num_layers=2,
+            hidden_size=128,
+            num_attention_heads=4,
+            use_cpu_initialization=True,
+            apply_rope_fusion=False,
+        )
+        assert config.apply_rope_fusion is False


### PR DESCRIPTION
Megatron-LM fails to utilize RoPE (Rotary Position Embedding) fusion optimization with newer versions of TransformerEngine that have deprecated the FusedRoPEFunc API in favor of apply_rotary_pos_emb.

File: /workspace/Megatron-LM/megatron/core/extensions/transformer_engine.py
The code tries to import FusedRoPEFunc from TransformerEngine:
```python
try:
    from transformer_engine.pytorch.attention import FusedRoPEFunc
    # defines fused_apply_rotary_pos_emb functions using FusedRoPEFunc
except ImportError:
    pass  # <-- BUG: Silently fails, doesn't define functions
```
When FusedRoPEFunc doesn't exist (newer TE versions), the except block just passes, leaving the functions undefined.

transformer_engine.py - Functions fused_apply_rotary_pos_emb and fused_apply_rotary_pos_emb_thd are never defined
rope_utils.py - Tries to import these undefined functions:
```python
try:
       from megatron.core.extensions.transformer_engine import (
           fused_apply_rotary_pos_emb,  # <-- Import fails
           fused_apply_rotary_pos_emb_thd,
       )
       HAVE_APPLY_ROPE_FUSION = True
   except ImportError:
       # Falls back to Apex
```
rope_utils.py - Falls back to Apex (if available), otherwise sets HAVE_APPLY_ROPE_FUSION = False
```python
transformer_config.py - Raises error when trying to use apply_rope_fusion=True:
```
ValueError: "apply_rope_fusion is not available. Please install TE >= 1.4 or Apex."
Making a PR to address this by adding fallback in transformer_engine.py to use the new apply_rotary_pos_emb API when FusedRoPEFunc isn't available. This maintains backward compatibility with old TE versions while supporting new ones.