### PR TITLE
Pytorch FSDP2 fp8 autocast sharding

### DIFF
--- a/examples/llama/train_llama3.sh
+++ b/examples/llama/train_llama3.sh
@@ -300,9 +300,6 @@ if [ "$TE_FP8" -eq 1 ]; then
         --fp8-amax-compute-algo=max \
         --attention-softmax-in-fp32 \
 "
-    if [ "$FSDP" -eq 1 ]; then
-        EXTRA_ARGS="$EXTRA_ARGS --keep_fp8_weight_transpose_cache" 
-    fi
 fi
 
 if [ -n "${WANDB_API_KEY}" ]; then

--- a/megatron/core/distributed/torch_fully_sharded_data_parallel.py
+++ b/megatron/core/distributed/torch_fully_sharded_data_parallel.py
@@ -86,7 +86,7 @@ class TorchFullyShardedDataParallel(_BaseDataParallel):
 
         self.ddp_config = ddp_config
 
-        def save_custom_attrs(module):
+        def save_custom_attrs(module, _SKIP_KEYS = {"_data", "_module", "_transpose"}):
             custom_attrs = {}
             for name, param in module.named_parameters():
                 attrs = vars(param)
@@ -97,9 +97,8 @@ class TorchFullyShardedDataParallel(_BaseDataParallel):
                     attrs['_fp8_attrs']['transpose_invalid'] = False
                     del attrs['_fp8_attrs']['transpose']
                 custom_attrs[name] = {k: v for k, v in attrs.items()}
-                custom_attrs[name].pop('_data', None)
-                custom_attrs[name].pop('_transpose', None)
-                custom_attrs[name].pop('_module', None)
+                for k in _SKIP_KEYS:
+                    custom_attrs[name].pop(k, None)
             return custom_attrs
 
         def restore_custom_attrs(module, custom_attrs):

--- a/megatron/core/distributed/torch_fully_sharded_data_parallel.py
+++ b/megatron/core/distributed/torch_fully_sharded_data_parallel.py
@@ -97,6 +97,9 @@ class TorchFullyShardedDataParallel(_BaseDataParallel):
                     attrs['_fp8_attrs']['transpose_invalid'] = False
                     del attrs['_fp8_attrs']['transpose']
                 custom_attrs[name] = {k: v for k, v in attrs.items()}
+                custom_attrs[name].pop('_data', None)
+                custom_attrs[name].pop('_transpose', None)
+                custom_attrs[name].pop('_module', None)
             return custom_attrs
 
         def restore_custom_attrs(module, custom_attrs):

--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -360,7 +360,7 @@ class TELinear(te.pytorch.Linear):
             assert class_has_init_param(te.pytorch.Linear, "keep_fp8_weight_transpose_cache"), "Transformer Engine v2.2.0 or later is required to use keep_fp8_weight_transpose_cache"
             extra_kwargs["keep_fp8_weight_transpose_cache"] = self.config.keep_fp8_weight_transpose_cache
         if is_te_min_version("2.4.0.dev0"):
-            assert class_has_init_param(te.pytorch.Linear, "use_fsdp2"), "Transformer Engine v2.2.0 or later is required to use use_fsdp2"
+            assert class_has_init_param(te.pytorch.Linear, "use_fsdp2"), "Transformer Engine v2.4.0 or later is required to use use_fsdp2"
             extra_kwargs["use_fsdp2"] = self.config.use_fsdp2
 
         super().__init__(
@@ -527,11 +527,11 @@ class TELayerNormColumnParallelLinear(te.pytorch.LayerNormLinear):
                     extra_kwargs["ub_name"] = tp_comm_buffer_name
 
         if is_te_min_version("2.2.0.dev0"):
-            assert class_has_init_param(te.pytorch.Linear, "keep_fp8_weight_transpose_cache"), "Transformer Engine v2.2.0 or later is required to use keep_fp8_weight_transpose_cache"
+            assert class_has_init_param(te.pytorch.LayerNormLinear, "keep_fp8_weight_transpose_cache"), "Transformer Engine v2.2.0 or later is required to use keep_fp8_weight_transpose_cache"
             extra_kwargs["keep_fp8_weight_transpose_cache"] = self.config.keep_fp8_weight_transpose_cache
 
         if is_te_min_version("2.4.0.dev0"):
-            assert class_has_init_param(te.pytorch.Linear, "use_fsdp2"), "Transformer Engine v2.2.0 or later is required to use use_fsdp2"
+            assert class_has_init_param(te.pytorch.LayerNormLinear, "use_fsdp2"), "Transformer Engine v2.4.0 or later is required to use use_fsdp2"
             extra_kwargs["use_fsdp2"] = self.config.use_fsdp2
         if self.config.symmetric_ar_type is not None:
             assert is_torch_min_version("2.7.0a0"), "Must have at least torch version 2.7 or higher"

--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -359,6 +359,9 @@ class TELinear(te.pytorch.Linear):
         if is_te_min_version("2.2.0.dev0"):
             assert class_has_init_param(te.pytorch.Linear, "keep_fp8_weight_transpose_cache"), "Transformer Engine v2.2.0 or later is required to use keep_fp8_weight_transpose_cache"
             extra_kwargs["keep_fp8_weight_transpose_cache"] = self.config.keep_fp8_weight_transpose_cache
+        if is_te_min_version("2.4.0.dev0"):
+            assert class_has_init_param(te.pytorch.Linear, "use_fsdp2"), "Transformer Engine v2.2.0 or later is required to use use_fsdp2"
+            extra_kwargs["use_fsdp2"] = self.config.use_fsdp2
 
         super().__init__(
             in_features=input_size,
@@ -527,6 +530,9 @@ class TELayerNormColumnParallelLinear(te.pytorch.LayerNormLinear):
             assert class_has_init_param(te.pytorch.Linear, "keep_fp8_weight_transpose_cache"), "Transformer Engine v2.2.0 or later is required to use keep_fp8_weight_transpose_cache"
             extra_kwargs["keep_fp8_weight_transpose_cache"] = self.config.keep_fp8_weight_transpose_cache
 
+        if is_te_min_version("2.4.0.dev0"):
+            assert class_has_init_param(te.pytorch.Linear, "use_fsdp2"), "Transformer Engine v2.2.0 or later is required to use use_fsdp2"
+            extra_kwargs["use_fsdp2"] = self.config.use_fsdp2
         if self.config.symmetric_ar_type is not None:
             assert is_torch_min_version("2.7.0a0"), "Must have at least torch version 2.7 or higher"
             assert is_te_min_version("2.3.0") or get_te_version() == PkgVersion(

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -617,6 +617,9 @@ class TransformerConfig(ModelParallelConfig):
     keep_fp8_weight_transpose_cache: bool = False
     """Don't cache the FP8 weight transposes to save memory"""
 
+    use_fsdp2: bool = False
+    """FSDP2 enable efficient sharding"""
+
     use_te_rng_tracker: bool = False
     """ Whether to use the TE or MCore version of the RNG tracker. """
 

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -618,7 +618,7 @@ class TransformerConfig(ModelParallelConfig):
     """Don't cache the FP8 weight transposes to save memory"""
 
     use_fsdp2: bool = False
-    """FSDP2 enable efficient sharding"""
+    """Enable FSDP2 efficient sharding"""
 
     use_te_rng_tracker: bool = False
     """ Whether to use the TE or MCore version of the RNG tracker. """

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1250,6 +1250,7 @@ def core_transformer_config_from_args(args, config_class=None):
         kw_args['disable_te_fused_rope'] = args.disable_te_fused_rope
         
     kw_args["cross_entropy_loss_fusion"] = args.cross_entropy_loss_fusion
+    kw_args["use_fsdp2"] = args.use_torch_fsdp2
     # Return config.
     return config_class(**kw_args)
 


### PR DESCRIPTION
## Motivation

Use the latest features to enable more efficient FSDP2 weight sharding.

## Technical Details

Pass in the use_fsdp2 flag to TE linear and layernorm linear modules, to use a better sharding implementation.

## Test Plan

Ran tests in TE, Ran llama3 examples with the new changes.

## Test Result

Benchmarking results: https://github.com/ROCm/frameworks-internal/issues/13926#issuecomment-3429151572

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
