### PR TITLE
Use e4m3 for both fwd and bwd for mxfp8.

### DIFF
--- a/examples/llama/train_llama2.sh
+++ b/examples/llama/train_llama2.sh
@@ -310,11 +310,13 @@ if [ "$MCORE" -eq 1 ]; then
 fi
 
 if [ "$TE_FP8" -eq 1 ]; then
-EXTRA_ARGS="$EXTRA_ARGS --transformer-impl=transformer_engine \
-    --fp8-format=hybrid \
+    EXTRA_ARGS="$EXTRA_ARGS --transformer-impl=transformer_engine \
 "
+
     if [ "$TE_FP8_RECIPE" == "delayed" ]; then
-        EXTRA_ARGS="$EXTRA_ARGS --fp8-margin=0 \
+        EXTRA_ARGS="$EXTRA_ARGS --fp8-recipe=delayed \
+            --fp8-format=hybrid \
+            --fp8-margin=0 \
             --fp8-interval=1 \
             --fp8-amax-history-len=1024 \
             --fp8-amax-compute-algo=max \
@@ -322,6 +324,7 @@ EXTRA_ARGS="$EXTRA_ARGS --transformer-impl=transformer_engine \
         "
     elif [ "$TE_FP8_RECIPE" == "mxfp8" ]; then
         EXTRA_ARGS="$EXTRA_ARGS --fp8-recipe=mxfp8 \
+            --fp8-format=e4m3 \
             --keep_fp8_weight_transpose_cache \
         "
         # Currently we have to keep fp8 weight tranpose cache due to an issue
@@ -329,6 +332,7 @@ EXTRA_ARGS="$EXTRA_ARGS --transformer-impl=transformer_engine \
         export NVTE_ROCM_ENABLE_MXFP8=1
     elif [ "$TE_FP8_RECIPE" == "tensorwise" ]; then
         EXTRA_ARGS="$EXTRA_ARGS --fp8-recipe=tensorwise \
+            --fp8-format=hybrid \
         "
     else
         echo "$TE_FP8_RECIPE is not supported"

--- a/examples/llama/train_llama3.sh
+++ b/examples/llama/train_llama3.sh
@@ -294,11 +294,12 @@ fi
 
 if [ "$TE_FP8" -eq 1 ]; then
     EXTRA_ARGS="$EXTRA_ARGS --transformer-impl=transformer_engine \
-        --fp8-format=hybrid \
 "
 
     if [ "$TE_FP8_RECIPE" == "delayed" ]; then
-        EXTRA_ARGS="$EXTRA_ARGS --fp8-margin=0 \
+        EXTRA_ARGS="$EXTRA_ARGS --fp8-recipe=delayed \
+            --fp8-format=hybrid \
+            --fp8-margin=0 \
             --fp8-interval=1 \
             --fp8-amax-history-len=1024 \
             --fp8-amax-compute-algo=max \
@@ -306,6 +307,7 @@ if [ "$TE_FP8" -eq 1 ]; then
         "
     elif [ "$TE_FP8_RECIPE" == "mxfp8" ]; then
         EXTRA_ARGS="$EXTRA_ARGS --fp8-recipe=mxfp8 \
+            --fp8-format=e4m3 \
             --keep_fp8_weight_transpose_cache \
         "
         # Currently we have to keep fp8 weight tranpose cache due to an issue
@@ -313,6 +315,7 @@ if [ "$TE_FP8" -eq 1 ]; then
         export NVTE_ROCM_ENABLE_MXFP8=1
     elif [ "$TE_FP8_RECIPE" == "tensorwise" ]; then
         EXTRA_ARGS="$EXTRA_ARGS --fp8-recipe=tensorwise \
+            --fp8-format=hybrid \
         "
     else
         echo "$TE_FP8_RECIPE is not supported"


### PR DESCRIPTION
# What does this PR do ?
Changed both fwd and bwd to use e4m3 for mxfp8 according to this paper: https://arxiv.org/abs/2506.08027