### PR TITLE
Update Dockerfile to use ROCm 7.1 base image

### DIFF
--- a/Dockerfile_rocm.ci
+++ b/Dockerfile_rocm.ci
@@ -1,4 +1,4 @@
-ARG BASE_DOCKER=rocm/pytorch:rocm7.0_ubuntu24.04_py3.12_pytorch_release_2.7.1
+ARG BASE_DOCKER=rocm/pytorch:rocm7.1_ubuntu24.04_py3.12_pytorch_release_2.9.1
 FROM $BASE_DOCKER
 
 ARG PYTORCH_ROCM_ARCH_OVERRIDE="gfx942"


### PR DESCRIPTION
# What does this PR do ?
This PR updates CI DockerFile to use ROCm7.1 base image instead of ROCm7.0 because of some known issues with hipblasLT FP8 GEMM kernels which aren't part of ROCm7.1.

For more information on analysis:
https://github.com/ROCm/frameworks-internal/issues/14376#issuecomment-3721545355
https://github.com/ROCm/frameworks-internal/issues/14376#issuecomment-3741424502

Fixes: [Megatron] Inf encountered with DeepSeek v2 fp8 with TE grouped GEMM
[#14376](https://github.com/ROCm/frameworks-internal/issues/14376)


## Contribution process

```mermaid
flowchart LR
    A[Pre-checks] --> B[PR Tests]
    subgraph Code Review/Approval
        C1[Expert Review] --> C2[Final Review]
    end
    B --> C1
    C2 --> D[Merge]
```

### Pre-checks

- [ ] I want this PR in a versioned release and have added the appropriate Milestone (e.g., `Core 0.8`)
- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR
