### PR TITLE
[Fix] Consolidate `--keep-fp8-transpose-cache` argument

### DIFF
--- a/examples/llama/README.md
+++ b/examples/llama/README.md
@@ -222,7 +222,9 @@ follow these steps for 2 Node run with Node0 as master node :
   `1` to enable Megatron-LM's custom FSDP with DTensor checkpointing (default: 0). It adds automatically `--use-megatron-fsdp --ckpt-format fsdp_dtensor` in the script. Of note, this disables `TP>1` automatically.
 
 - **FP8_PARAM_GATHER:**
-  Controls FP8 primaries vs FP8 caches when `TE_FP8=1` (default: 0). Set to `1` to add `--fp8-param-gather` (weights kept in FP8, smaller all-gathers). Set to `0` to skip the `--fp8-param-gather` flag (weights stay BF16, FP8 caches are used for compute; FP8 weight transpose cache is still kept). Currently, `FP8_PARAM_GATHER` and `TE_FP8_RECIPE` set to `mxfp8` cannot be used together, resulting in the `FP8_PARAM_GATHER` flag to be ignored.
+  Controls FP8 primaries vs FP8 caches when `TE_FP8=1` (default: 0). Set to `1` to add `--fp8-param-gather` (weights kept in FP8, smaller all-gathers). Set to `0` to skip the `--fp8-param-gather` flag (weights stay BF16, FP8 caches are used for compute; FP8 weight transpose cache is still kept). Currently, `FP8_PARAM_GATHER` and `TE_FP8_RECIPE` set to `mxfp8` cannot be used together, resulting in the `FP8_PARAM_GATHER` flag to be ignored. 
+  
+  Warning: FSDP2 FP8 param gather is not supported yet and it falls back to BF16 `all_gather` instead, turning off `fp8_param_gather`.
 
 - **ENABLE_PROFILING:**  
   `1` to enable PyTorch profiling for performance analysis (default: 0).

--- a/examples/llama/README.md
+++ b/examples/llama/README.md
@@ -222,7 +222,7 @@ follow these steps for 2 Node run with Node0 as master node :
   `1` to enable Megatron-LM's custom FSDP with DTensor checkpointing (default: 0). It adds automatically `--use-megatron-fsdp --ckpt-format fsdp_dtensor` in the script. Of note, this disables `TP>1` automatically.
 
 - **FP8_PARAM_GATHER:**
-  Controls FP8 primaries vs FP8 caches when `TE_FP8=1` (default: 0). Set to `1` to add `--fp8-param-gather` (weights kept in FP8, smaller all-gathers). Set to `0` to skip the `--fp8-param-gather` flag (weights stay BF16, FP8 caches are used for compute; FP8 weight transpose cache is still kept). Currently, `FP8_PARAM_GATHER` and `TE_FP8_RECIPE` set to `mxfp8` cannot be used together, resulting in the `FP8_PARAM_GATHER` flag to be ignored. 
+  Controls FP8 primaries vs FP8 caches when `TE_FP8=1` (default: 0). Set to `1` to add `--fp8-param-gather` (weights kept in FP8, smaller all-gathers). Set to `0` to skip the `--fp8-param-gather` flag (weights stay BF16, FP8 caches are used for compute; FP8 weight transpose cache is still kept). 
   
   Warning: FSDP2 FP8 param gather is not supported yet and it falls back to BF16 `all_gather` instead, turning off `fp8_param_gather`.
 

--- a/examples/llama/README.md
+++ b/examples/llama/README.md
@@ -205,6 +205,9 @@ follow these steps for 2 Node run with Node0 as master node :
 
 - **TE_FP8_RECIPE:**  
   `delayed` (default), `tensorwise`, `mxfp8` (supported on MI350) 
+  
+- **FP8_TRANSPOSE_CACHE:**  
+  `0` (default), `1` Keeps the fp8 weight transpose cache in memory to avoid recomputing it, boosting performance but using more memory. Automatically set to `1` if `TE_FP8_RECIPE` is set to `mxfp8`.
 
 - **GEMM_TUNING:**  
   `1` (default) to enable GEMM tuning, which boosts performance by using the best GEMM kernels. Currently not supported for `mxfp8`.
@@ -219,7 +222,7 @@ follow these steps for 2 Node run with Node0 as master node :
   `1` to enable Megatron-LM's custom FSDP with DTensor checkpointing (default: 0). It adds automatically `--use-megatron-fsdp --ckpt-format fsdp_dtensor` in the script. Of note, this disables `TP>1` automatically.
 
 - **FP8_PARAM_GATHER:**
-  Controls FP8 primaries vs FP8 caches when `TE_FP8=1` and `MEGATRON_FSDP=1` (default: 0). Set to `1` to add --fp8-param-gather` (weights kept in FP8, smaller all-gathers). Set to `0` to skip the `--fp8-param-gather` flag (weights stay BF16, FP8 caches are used for compute; FP8 weight transpose cache is still kept).
+  Controls FP8 primaries vs FP8 caches when `TE_FP8=1` and `MEGATRON_FSDP=1` (default: 0). Set to `1` to add `--fp8-param-gather` (weights kept in FP8, smaller all-gathers). Set to `0` to skip the `--fp8-param-gather` flag (weights stay BF16, FP8 caches are used for compute; FP8 weight transpose cache is still kept). Currently, `FP8_PARAM_GATHER` and `TE_FP8_RECIPE` set to `mxfp8` cannot be used together, resulting in the `FP8_PARAM_GATHER` flag to be ignored.
 
 - **ENABLE_PROFILING:**  
   `1` to enable PyTorch profiling for performance analysis (default: 0).

--- a/examples/llama/README.md
+++ b/examples/llama/README.md
@@ -164,7 +164,7 @@ distributed optimizer, gradient accumulation fusion and fp16.
 
 #### FP8 options with Megatron-LM FSDP (train_llama3.sh)
   - **FP8 primary weights (fp8_model_init, param gather):** `TE_FP8=1 MEGATRON_FSDP=1 FP8_PARAM_GATHER=1 bash examples/llama/train_llama3.sh`
-  - **BF16 primaries + FP8 caches (fp8_autocast):** `TE_FP8=1 MEGATRON_FSDP=1 FP8_PARAM_GATHER=0 bash examples/llama/train_llama3.sh`
+  - **BF16 primary weights + FP8 caches (fp8_autocast):** `TE_FP8=1 MEGATRON_FSDP=1 FP8_PARAM_GATHER=0 bash examples/llama/train_llama3.sh`
   - Of note: the script always keeps the FP8 weight transpose cache for Megatron FSDP when FP8 is on; turning off `FP8_PARAM_GATHER` only removes the `--fp8-param-gather` flag.
 
 
@@ -222,7 +222,7 @@ follow these steps for 2 Node run with Node0 as master node :
   `1` to enable Megatron-LM's custom FSDP with DTensor checkpointing (default: 0). It adds automatically `--use-megatron-fsdp --ckpt-format fsdp_dtensor` in the script. Of note, this disables `TP>1` automatically.
 
 - **FP8_PARAM_GATHER:**
-  Controls FP8 primaries vs FP8 caches when `TE_FP8=1` (default: 0). Set to `1` to add `--fp8-param-gather` (weights kept in FP8, smaller all-gathers). Set to `0` to skip the `--fp8-param-gather` flag (weights stay BF16, FP8 caches are used for compute; FP8 weight transpose cache is still kept). 
+  Controls FP8 primary weights vs FP8 caches when `TE_FP8=1` (default: 0). Set to `1` to add `--fp8-param-gather` (weights kept in FP8, smaller all-gathers). Set to `0` to skip the `--fp8-param-gather` flag (weights stay BF16, FP8 caches are used for compute; FP8 weight transpose cache is still kept). 
   
   Warning: FSDP2 FP8 param gather is not supported yet and it falls back to BF16 `all_gather` instead, turning off `fp8_param_gather`.
 

--- a/examples/llama/README.md
+++ b/examples/llama/README.md
@@ -207,7 +207,7 @@ follow these steps for 2 Node run with Node0 as master node :
   `delayed` (default), `tensorwise`, `mxfp8` (supported on MI350) 
   
 - **FP8_TRANSPOSE_CACHE:**  
-  `0` (default), `1` Keeps the fp8 weight transpose cache in memory to avoid recomputing it, boosting performance but using more memory. Automatically set to `1` if `TE_FP8_RECIPE` is set to `mxfp8`.
+  `0` (default), `1` Keeps the fp8 weight transpose cache in memory to avoid recomputing it, boosting performance but using more memory.
 
 - **GEMM_TUNING:**  
   `1` (default) to enable GEMM tuning, which boosts performance by using the best GEMM kernels. Currently not supported for `mxfp8`.
@@ -222,7 +222,7 @@ follow these steps for 2 Node run with Node0 as master node :
   `1` to enable Megatron-LM's custom FSDP with DTensor checkpointing (default: 0). It adds automatically `--use-megatron-fsdp --ckpt-format fsdp_dtensor` in the script. Of note, this disables `TP>1` automatically.
 
 - **FP8_PARAM_GATHER:**
-  Controls FP8 primaries vs FP8 caches when `TE_FP8=1` and `MEGATRON_FSDP=1` (default: 0). Set to `1` to add `--fp8-param-gather` (weights kept in FP8, smaller all-gathers). Set to `0` to skip the `--fp8-param-gather` flag (weights stay BF16, FP8 caches are used for compute; FP8 weight transpose cache is still kept). Currently, `FP8_PARAM_GATHER` and `TE_FP8_RECIPE` set to `mxfp8` cannot be used together, resulting in the `FP8_PARAM_GATHER` flag to be ignored.
+  Controls FP8 primaries vs FP8 caches when `TE_FP8=1` (default: 0). Set to `1` to add `--fp8-param-gather` (weights kept in FP8, smaller all-gathers). Set to `0` to skip the `--fp8-param-gather` flag (weights stay BF16, FP8 caches are used for compute; FP8 weight transpose cache is still kept). Currently, `FP8_PARAM_GATHER` and `TE_FP8_RECIPE` set to `mxfp8` cannot be used together, resulting in the `FP8_PARAM_GATHER` flag to be ignored.
 
 - **ENABLE_PROFILING:**  
   `1` to enable PyTorch profiling for performance analysis (default: 0).

--- a/examples/llama/train_llama2.sh
+++ b/examples/llama/train_llama2.sh
@@ -334,12 +334,17 @@ if [ "$TE_FP8" -eq 1 ]; then
             --attention-softmax-in-fp32 \
         "
     elif [ "$TE_FP8_RECIPE" == "mxfp8" ]; then
-        EXTRA_ARGS="$EXTRA_ARGS --fp8-recipe=mxfp8 \
-            --fp8-format=e4m3 \
-        "
-        # Currently we have to keep fp8 weight tranpose cache due to an issue
-        # Also, TE does not enable mxfp8 by default
-        export NVTE_ROCM_ENABLE_MXFP8=1
+        if [ "$FSDP" -eq 1 ] || [ "$MEGATRON_FSDP" -eq 1 ]; then
+            EXTRA_ARGS="$EXTRA_ARGS --fp8-recipe=mxfp8 \
+                --fp8-format=e4m3 \
+            "
+            # Also, TE does not enable mxfp8 by default
+            export NVTE_ROCM_ENABLE_MXFP8=1
+        else 
+            echo "Llama2 supports MXFP8 only for FSDP and MEGATRON_FSDP."
+            exit
+        fi
+        
     elif [ "$TE_FP8_RECIPE" == "tensorwise" ]; then
         EXTRA_ARGS="$EXTRA_ARGS --fp8-recipe=tensorwise \
             --fp8-format=hybrid \
@@ -353,7 +358,11 @@ if [ "$TE_FP8" -eq 1 ]; then
         if [[ "$TE_FP8_RECIPE" != "mxfp8" ]]; then
             EXTRA_ARGS="$EXTRA_ARGS --fp8-param-gather"
         else
-            echo "Warning: FP8_PARAM_GATHER and MXFP8 cannot be currently used together. Ignoring FP8_PARAM_GATHER flag."
+            if [[ "$FSDP" -eq 1 ]]; then
+                EXTRA_ARGS="$EXTRA_ARGS --fp8-param-gather"
+            else
+                echo "Warning: FP8_PARAM_GATHER and MXFP8 cannot be currently used together, unless FSDP=1. Ignoring FP8_PARAM_GATHER flag."
+            fi
         fi
     fi
 

--- a/examples/llama/train_llama2.sh
+++ b/examples/llama/train_llama2.sh
@@ -86,6 +86,7 @@ EVAL_ITERS="${EVAL_ITERS:-'-1'}"
 DATA_CACHE_PATH="${DATA_CACHE_PATH:-/root/cache}"
 MEGATRON_FSDP="${MEGATRON_FSDP:-0}"
 FP8_PARAM_GATHER="${FP8_PARAM_GATHER:-0}"
+FP8_TRANSPOSE_CACHE="${FP8_TRANSPOSE_CACHE:-0}"
 
 TOKENIZER_TYPE="${TOKENIZER_TYPE:-HuggingFaceTokenizer}"
 if [ "$TOKENIZER_TYPE" == "Llama2Tokenizer" ]; then
@@ -330,8 +331,8 @@ if [ "$TE_FP8" -eq 1 ]; then
     elif [ "$TE_FP8_RECIPE" == "mxfp8" ]; then
         EXTRA_ARGS="$EXTRA_ARGS --fp8-recipe=mxfp8 \
             --fp8-format=e4m3 \
-            --keep_fp8_weight_transpose_cache \
         "
+        FP8_TRANSPOSE_CACHE=1
         # Currently we have to keep fp8 weight tranpose cache due to an issue
         # Also, TE does not enable mxfp8 by default
         export NVTE_ROCM_ENABLE_MXFP8=1
@@ -344,12 +345,18 @@ if [ "$TE_FP8" -eq 1 ]; then
         exit
     fi
 
-    if [ "$FP8_PARAM_GATHER" -eq 1 ]; then
-        EXTRA_ARGS="$EXTRA_ARGS --fp8-param-gather" 
+    if [[ "$FP8_PARAM_GATHER" -eq 1 ]]; then
+        if [[ "$TE_FP8_RECIPE" != "mxfp8" ]]; then
+            EXTRA_ARGS="$EXTRA_ARGS --fp8-param-gather"
+        else
+            echo "Warning: FP8_PARAM_GATHER and MXFP8 cannot be currently used together. Ignoring FP8_PARAM_GATHER flag."
+        fi
     fi
 
-    if [ "$MEGATRON_FSDP" -eq 1 ]; then
-        EXTRA_ARGS="$EXTRA_ARGS --keep_fp8_weight_transpose_cache" 
+    if [ "$FP8_TRANSPOSE_CACHE" -eq 1 ]; then
+        EXTRA_ARGS="$EXTRA_ARGS --keep-fp8-weight-transpose-cache-te \
+            --keep-fp8-transpose-cache \
+        " 
     fi
     
 fi

--- a/examples/llama/train_llama2.sh
+++ b/examples/llama/train_llama2.sh
@@ -337,7 +337,6 @@ if [ "$TE_FP8" -eq 1 ]; then
         EXTRA_ARGS="$EXTRA_ARGS --fp8-recipe=mxfp8 \
             --fp8-format=e4m3 \
         "
-        FP8_TRANSPOSE_CACHE=1
         # Currently we have to keep fp8 weight tranpose cache due to an issue
         # Also, TE does not enable mxfp8 by default
         export NVTE_ROCM_ENABLE_MXFP8=1

--- a/examples/llama/train_llama2.sh
+++ b/examples/llama/train_llama2.sh
@@ -289,11 +289,11 @@ if [ "$FSDP" -eq 1 ]; then
         SEQ_PARALLEL=0
     fi
 
-    if [ "$TE_FP8_RECIPE" == "mxfp8" ]; then
-        echo "Warning: FSDP2 and MXFP8 do not currently work together."
-        echo "FSDP2 and MXFP8 are on. Disabling MXFP8, setting TE_FP8_RECIPE to 'delayed'."
-        TE_FP8_RECIPE="delayed"
-    fi
+    # if [ "$TE_FP8_RECIPE" == "mxfp8" ]; then
+    #     echo "Warning: FSDP2 and MXFP8 do not currently work together."
+    #     echo "FSDP2 and MXFP8 are on. Disabling MXFP8, setting TE_FP8_RECIPE to 'delayed'."
+    #     TE_FP8_RECIPE="delayed"
+    # fi
 else
     if [ "$OPTIMIZER" == "adam" ]; then
         EXTRA_ARGS="$EXTRA_ARGS --use-distributed-optimizer --overlap-param-gather"
@@ -334,14 +334,14 @@ if [ "$TE_FP8" -eq 1 ]; then
             --attention-softmax-in-fp32 \
         "
     elif [ "$TE_FP8_RECIPE" == "mxfp8" ]; then
-        if [ "$FSDP" -eq 1 ] || [ "$MEGATRON_FSDP" -eq 1 ]; then
+        if [ "$MEGATRON_FSDP" -eq 1 ]; then
             EXTRA_ARGS="$EXTRA_ARGS --fp8-recipe=mxfp8 \
                 --fp8-format=e4m3 \
             "
-            # Also, TE does not enable mxfp8 by default
+        # TE does not enable mxfp8 by default
             export NVTE_ROCM_ENABLE_MXFP8=1
         else 
-            echo "Llama2 supports MXFP8 only for FSDP and MEGATRON_FSDP."
+            echo "Error: Llama2 supports MXFP8 only for MEGATRON_FSDP."
             exit
         fi
         
@@ -354,15 +354,12 @@ if [ "$TE_FP8" -eq 1 ]; then
         exit
     fi
 
-    if [[ "$FP8_PARAM_GATHER" -eq 1 ]]; then
-        if [[ "$TE_FP8_RECIPE" != "mxfp8" ]]; then
+    if [ "$FP8_PARAM_GATHER" -eq 1 ]; then
+        if [ "$TE_FP8_RECIPE" != "mxfp8" ]; then
             EXTRA_ARGS="$EXTRA_ARGS --fp8-param-gather"
         else
-            if [[ "$FSDP" -eq 1 ]]; then
-                EXTRA_ARGS="$EXTRA_ARGS --fp8-param-gather"
-            else
-                echo "Warning: FP8_PARAM_GATHER and MXFP8 cannot be currently used together, unless FSDP=1. Ignoring FP8_PARAM_GATHER flag."
-            fi
+            echo "Error: For Llama2 FP8_PARAM_GATHER and MXFP8 cannot be currently used together."
+            exit
         fi
     fi
 

--- a/examples/llama/train_llama2.sh
+++ b/examples/llama/train_llama2.sh
@@ -282,12 +282,17 @@ EXTRA_ARGS="
 "
 
 if [ "$FSDP" -eq 1 ]; then
-    unset CUDA_DEVICE_MAX_CONNECTIONS
     EXTRA_ARGS="$EXTRA_ARGS --use-torch-fsdp2"
     if [ "$SEQ_PARALLEL" -eq 1 ]; then
         echo "Warning: Sequence Parallelism and FSDP2 have conflicting CUDA_MAX_CONNECTIONS requirements. It is recommended not to use them together."
         echo "FSDP2 and sequence parallel are on. Disabling sequence parallel."
         SEQ_PARALLEL=0
+    fi
+
+    if [ "$TE_FP8_RECIPE" == "mxfp8" ]; then
+        echo "Warning: FSDP2 and MXFP8 do not currently work together."
+        echo "FSDP2 and MXFP8 are on. Disabling MXFP8, setting TE_FP8_RECIPE to 'delayed'."
+        TE_FP8_RECIPE="delayed"
     fi
 else
     if [ "$OPTIMIZER" == "adam" ]; then

--- a/examples/llama/train_llama2.sh
+++ b/examples/llama/train_llama2.sh
@@ -288,12 +288,6 @@ if [ "$FSDP" -eq 1 ]; then
         echo "FSDP2 and sequence parallel are on. Disabling sequence parallel."
         SEQ_PARALLEL=0
     fi
-
-    # if [ "$TE_FP8_RECIPE" == "mxfp8" ]; then
-    #     echo "Warning: FSDP2 and MXFP8 do not currently work together."
-    #     echo "FSDP2 and MXFP8 are on. Disabling MXFP8, setting TE_FP8_RECIPE to 'delayed'."
-    #     TE_FP8_RECIPE="delayed"
-    # fi
 else
     if [ "$OPTIMIZER" == "adam" ]; then
         EXTRA_ARGS="$EXTRA_ARGS --use-distributed-optimizer --overlap-param-gather"
@@ -338,7 +332,7 @@ if [ "$TE_FP8" -eq 1 ]; then
             EXTRA_ARGS="$EXTRA_ARGS --fp8-recipe=mxfp8 \
                 --fp8-format=e4m3 \
             "
-        # TE does not enable mxfp8 by default
+            # TE does not enable mxfp8 by default
             export NVTE_ROCM_ENABLE_MXFP8=1
         else 
             echo "Error: Llama2 supports MXFP8 only for MEGATRON_FSDP."

--- a/examples/llama/train_llama3.sh
+++ b/examples/llama/train_llama3.sh
@@ -87,6 +87,7 @@ CKPT_FORMAT="${CKPT_FORMAT:-torch}"
 DATA_CACHE_PATH="${DATA_CACHE_PATH:-/root/cache}"
 MEGATRON_FSDP="${MEGATRON_FSDP:-0}"
 FP8_PARAM_GATHER="${FP8_PARAM_GATHER:-0}"
+FP8_TRANSPOSE_CACHE="${FP8_TRANSPOSE_CACHE:-0}"
 
 if [ "$FSDP" -eq 1 ] || [ "$MEGATRON_FSDP" -eq 1 ]; then
     unset CUDA_DEVICE_MAX_CONNECTIONS
@@ -310,8 +311,8 @@ if [ "$TE_FP8" -eq 1 ]; then
     elif [ "$TE_FP8_RECIPE" == "mxfp8" ]; then
         EXTRA_ARGS="$EXTRA_ARGS --fp8-recipe=mxfp8 \
             --fp8-format=e4m3 \
-            --keep_fp8_weight_transpose_cache \
         "
+        FP8_TRANSPOSE_CACHE=1
         # Currently we have to keep fp8 weight tranpose cache due to an issue
         # Also, TE does not enable mxfp8 by default
         export NVTE_ROCM_ENABLE_MXFP8=1
@@ -324,12 +325,18 @@ if [ "$TE_FP8" -eq 1 ]; then
         exit
     fi
 
-    if [ "$FP8_PARAM_GATHER" -eq 1 ]; then
-        EXTRA_ARGS="$EXTRA_ARGS --fp8-param-gather" 
+    if [[ "$FP8_PARAM_GATHER" -eq 1 ]]; then
+        if [[ "$TE_FP8_RECIPE" != "mxfp8" ]]; then
+            EXTRA_ARGS="$EXTRA_ARGS --fp8-param-gather"
+        else
+            echo "Warning: FP8_PARAM_GATHER and MXFP8 cannot be currently used together. Ignoring FP8_PARAM_GATHER flag."
+        fi
     fi
 
-    if [ "$MEGATRON_FSDP" -eq 1 ]; then
-        EXTRA_ARGS="$EXTRA_ARGS --keep_fp8_weight_transpose_cache" 
+    if [ "$FP8_TRANSPOSE_CACHE" -eq 1 ]; then
+        EXTRA_ARGS="$EXTRA_ARGS --keep-fp8-weight-transpose-cache-te \
+            --keep-fp8-transpose-cache \
+        " 
     fi
 fi
 

--- a/examples/llama/train_llama3.sh
+++ b/examples/llama/train_llama3.sh
@@ -312,7 +312,6 @@ if [ "$TE_FP8" -eq 1 ]; then
         EXTRA_ARGS="$EXTRA_ARGS --fp8-recipe=mxfp8 \
             --fp8-format=e4m3 \
         "
-        # Currently we have to keep fp8 weight tranpose cache due to an issue
         # Also, TE does not enable mxfp8 by default
         export NVTE_ROCM_ENABLE_MXFP8=1
     elif [ "$TE_FP8_RECIPE" == "tensorwise" ]; then
@@ -328,7 +327,11 @@ if [ "$TE_FP8" -eq 1 ]; then
         if [[ "$TE_FP8_RECIPE" != "mxfp8" ]]; then
             EXTRA_ARGS="$EXTRA_ARGS --fp8-param-gather"
         else
-            echo "Warning: FP8_PARAM_GATHER and MXFP8 cannot be currently used together. Ignoring FP8_PARAM_GATHER flag."
+            if [[ "$FSDP" -eq 1 ]]; then
+                EXTRA_ARGS="$EXTRA_ARGS --fp8-param-gather"
+            else
+                echo "Warning: FP8_PARAM_GATHER and MXFP8 cannot be currently used together, unless FSDP=1. Ignoring FP8_PARAM_GATHER flag."
+            fi
         fi
     fi
 

--- a/examples/llama/train_llama3.sh
+++ b/examples/llama/train_llama3.sh
@@ -312,7 +312,7 @@ if [ "$TE_FP8" -eq 1 ]; then
         EXTRA_ARGS="$EXTRA_ARGS --fp8-recipe=mxfp8 \
             --fp8-format=e4m3 \
         "
-        # Also, TE does not enable mxfp8 by default
+        # TE does not enable mxfp8 by default
         export NVTE_ROCM_ENABLE_MXFP8=1
     elif [ "$TE_FP8_RECIPE" == "tensorwise" ]; then
         EXTRA_ARGS="$EXTRA_ARGS --fp8-recipe=tensorwise \
@@ -323,15 +323,12 @@ if [ "$TE_FP8" -eq 1 ]; then
         exit
     fi
 
-    if [[ "$FP8_PARAM_GATHER" -eq 1 ]]; then
-        if [[ "$TE_FP8_RECIPE" != "mxfp8" ]]; then
+    if [ "$FP8_PARAM_GATHER" -eq 1 ]; then
+        if [ "$TE_FP8_RECIPE" == "mxfp8" ]  && [ "$FSDP" -eq 1 ]; then
             EXTRA_ARGS="$EXTRA_ARGS --fp8-param-gather"
         else
-            if [[ "$FSDP" -eq 1 ]]; then
-                EXTRA_ARGS="$EXTRA_ARGS --fp8-param-gather"
-            else
-                echo "Warning: FP8_PARAM_GATHER and MXFP8 cannot be currently used together, unless FSDP=1. Ignoring FP8_PARAM_GATHER flag."
-            fi
+            echo "Error: For Llama3 FP8_PARAM_GATHER and MXFP8 cannot be currently used together, unless FSDP=1"
+            exit
         fi
     fi
 

--- a/examples/llama/train_llama3.sh
+++ b/examples/llama/train_llama3.sh
@@ -312,7 +312,6 @@ if [ "$TE_FP8" -eq 1 ]; then
         EXTRA_ARGS="$EXTRA_ARGS --fp8-recipe=mxfp8 \
             --fp8-format=e4m3 \
         "
-        FP8_TRANSPOSE_CACHE=1
         # Currently we have to keep fp8 weight tranpose cache due to an issue
         # Also, TE does not enable mxfp8 by default
         export NVTE_ROCM_ENABLE_MXFP8=1

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -910,6 +910,42 @@ def validate_args(args, defaults={}):
                 "Using tensor model parallelism or context parallelism require setting the environment variable " \
                 "CUDA_DEVICE_MAX_CONNECTIONS to 1"
 
+# is_rocm = hasattr(torch.version, "hip") and torch.version.hip is not None
+#     if (args.tensor_model_parallel_size > 1 or args.context_parallel_size > 1) \
+#         and get_device_arch_version() < 10:
+#         # CUDA_DEVICE_MAX_CONNECTIONS requirement no longer exists since the Blackwell architecture
+#         if args.use_torch_fsdp2 or args.use_megatron_fsdp:
+#             fsdp_impl = "Torch-FSDP2" if args.use_torch_fsdp2 else "Megatron-FSDP"
+#             warn_rank_0(
+#                 f"Using tensor model parallelism or context parallelism with {fsdp_impl} together. "
+#                 "Try not to using them together since they require different CUDA_MAX_CONNECTIONS "
+#                 "settings for best performance. sequence parallelism requires setting the "
+#                 f"environment variable CUDA_DEVICE_MAX_CONNECTIONS to 1 while {fsdp_impl} "
+#                 "requires not setting CUDA_DEVICE_MAX_CONNECTIONS=1 for better parallelization.",
+#                 args.rank,
+#             )
+#         elif args.overlap_moe_expert_parallel_comm:
+#             warn_rank_0(
+#                 "For Hopper and before, try not to use tensor model parallelism or context parallelism with overlap_moe_expert_parallel_comm. "
+#                 "Using tensor/context model parallelism requires setting the environment "
+#                 "variable CUDA_DEVICE_MAX_CONNECTIONS to 1 to maximize the performance. "
+#                 "While overlap_moe_expert_parallel_comm requires setting a larger CUDA_DEVICE_MAX_CONNECTIONS "
+#                 "for better parallelization. If you want to use both, you can set CUDA_DEVICE_MAX_CONNECTIONS to 1 or 32, "
+#                 "which depends on which parallelization you want to prioritize.",
+#                 args.rank,
+#             )
+#         else:
+#             if is_rocm:
+#                 fsdp_impl = "Torch-FSDP2" if args.use_torch_fsdp2 else "Megatron-FSDP"
+#                 warn_rank_0(
+#                     "Runing on ROCm: CUDA_DEVICE_MAX_CONNECTIONS is not used. "
+#                     "Set it to a ROCm-friendly value (e.g., 8) or leave unset.",
+#                     args.rank,
+#                 )
+#             else:
+#                 assert os.environ.get('CUDA_DEVICE_MAX_CONNECTIONS') == "1", \
+#                     "Using tensor model parallelism or context parallelism require setting the environment variable " \
+#                     "CUDA_DEVICE_MAX_CONNECTIONS to 1"
     # Setting FSDP communication groups for high priority streams for Blackwell and later architectures
     # Assigning high priority to communication streams ensures that communication kernels are scheduled
     # with higher priority, minimizing the exposed communication when it is overlapped with other computation kernels.
@@ -1290,9 +1326,11 @@ def _add_transformer_engine_args(parser):
     group.add_argument('--fp8-param-gather', action='store_true',
                        help='Keep the compute param in fp8 (do not use any other intermediate '
                             'dtype) and perform the param all-gather in fp8.')
-    group.add_argument('--keep_fp8_weight_transpose_cache', action='store_true', 
+    group.add_argument('--keep-fp8-weight-transpose-cache-te', action='store_true', dest='keep_fp8_weight_transpose_cache',
                        help='Keep the fp8 weight transpose cache in memory to avoid recomputing it '
                             ' This will use more memory')
+    group.add_argument('--keep_fp8_weight_transpose_cache', action='store_true', dest='deprecated_keep_fp8_weight_transpose_cache',
+                       help='DEPRECATED: Use --keep-fp8-weight-transpose-cache-te instead')
 
     group.add_argument('--first-last-layers-bf16', action='store_true',
                        help='Construct first and last layers in bf16 when doing FP8 training.')

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -910,42 +910,6 @@ def validate_args(args, defaults={}):
                 "Using tensor model parallelism or context parallelism require setting the environment variable " \
                 "CUDA_DEVICE_MAX_CONNECTIONS to 1"
 
-# is_rocm = hasattr(torch.version, "hip") and torch.version.hip is not None
-#     if (args.tensor_model_parallel_size > 1 or args.context_parallel_size > 1) \
-#         and get_device_arch_version() < 10:
-#         # CUDA_DEVICE_MAX_CONNECTIONS requirement no longer exists since the Blackwell architecture
-#         if args.use_torch_fsdp2 or args.use_megatron_fsdp:
-#             fsdp_impl = "Torch-FSDP2" if args.use_torch_fsdp2 else "Megatron-FSDP"
-#             warn_rank_0(
-#                 f"Using tensor model parallelism or context parallelism with {fsdp_impl} together. "
-#                 "Try not to using them together since they require different CUDA_MAX_CONNECTIONS "
-#                 "settings for best performance. sequence parallelism requires setting the "
-#                 f"environment variable CUDA_DEVICE_MAX_CONNECTIONS to 1 while {fsdp_impl} "
-#                 "requires not setting CUDA_DEVICE_MAX_CONNECTIONS=1 for better parallelization.",
-#                 args.rank,
-#             )
-#         elif args.overlap_moe_expert_parallel_comm:
-#             warn_rank_0(
-#                 "For Hopper and before, try not to use tensor model parallelism or context parallelism with overlap_moe_expert_parallel_comm. "
-#                 "Using tensor/context model parallelism requires setting the environment "
-#                 "variable CUDA_DEVICE_MAX_CONNECTIONS to 1 to maximize the performance. "
-#                 "While overlap_moe_expert_parallel_comm requires setting a larger CUDA_DEVICE_MAX_CONNECTIONS "
-#                 "for better parallelization. If you want to use both, you can set CUDA_DEVICE_MAX_CONNECTIONS to 1 or 32, "
-#                 "which depends on which parallelization you want to prioritize.",
-#                 args.rank,
-#             )
-#         else:
-#             if is_rocm:
-#                 fsdp_impl = "Torch-FSDP2" if args.use_torch_fsdp2 else "Megatron-FSDP"
-#                 warn_rank_0(
-#                     "Runing on ROCm: CUDA_DEVICE_MAX_CONNECTIONS is not used. "
-#                     "Set it to a ROCm-friendly value (e.g., 8) or leave unset.",
-#                     args.rank,
-#                 )
-#             else:
-#                 assert os.environ.get('CUDA_DEVICE_MAX_CONNECTIONS') == "1", \
-#                     "Using tensor model parallelism or context parallelism require setting the environment variable " \
-#                     "CUDA_DEVICE_MAX_CONNECTIONS to 1"
     # Setting FSDP communication groups for high priority streams for Blackwell and later architectures
     # Assigning high priority to communication streams ensures that communication kernels are scheduled
     # with higher priority, minimizing the exposed communication when it is overlapped with other computation kernels.

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1114,6 +1114,15 @@ def validate_args(args, defaults={}):
     if args.load_main_params_from_ckpt:
         assert args.no_load_optim, '--load-main-params-from-ckpt must be used with --no-load-optim.'
 
+    # Training args
+    if getattr(args, "deprecated_keep_fp8_weight_transpose_cache", False):
+        if args.rank == 0:
+            print(
+                "--keep_fp8_weight_transpose_cache is deprecated and has no effect. "
+                "Use --keep-fp8-weight-transpose-cache-te instead."
+            )
+            args.keep_fp8_weight_transpose_cache = True
+
     # Inference args
     if args.inference_batch_times_seqlen_threshold > -1:
         assert args.pipeline_model_parallel_size > 1, \


### PR DESCRIPTION
## Motivation

Review and consolidate --keep-fp8-transpose-cache flag in Megatron-LM

## Technical Details

Fixes issue https://github.com/ROCm/frameworks-internal/issues/15056

## Test Plan

Ran Llama3 and Llama2 examples with the new changes.

## Test Result

All tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
