### PR TITLE
Megatron CI TE 2.10 Upgrade

### DIFF
--- a/.github/workflows/megatron-ci.yml
+++ b/.github/workflows/megatron-ci.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/megatron-ci.yml
+++ b/.github/workflows/megatron-ci.yml
@@ -68,7 +68,7 @@ jobs:
         id: te-ref
         run: |
           set -e
-          BRANCH=sudhu/release_v2.8_rocm_cherrypicks
+          BRANCH=sudhu/release_v2.10_rocm_cherrypicks
           SHA=$(git ls-remote https://github.com/ROCm/TransformerEngine.git "refs/heads/$BRANCH" | cut -f1)
           if [ -z "$SHA" ]; then
             echo "::error::Failed to resolve TransformerEngine commit for branch $BRANCH"

--- a/.github/workflows/megatron-ci.yml
+++ b/.github/workflows/megatron-ci.yml
@@ -68,7 +68,7 @@ jobs:
         id: te-ref
         run: |
           set -e
-          BRANCH=sudhu/release_v2.10_rocm_cherrypicks
+          BRANCH=release_v2.10_rocm
           SHA=$(git ls-remote https://github.com/ROCm/TransformerEngine.git "refs/heads/$BRANCH" | cut -f1)
           if [ -z "$SHA" ]; then
             echo "::error::Failed to resolve TransformerEngine commit for branch $BRANCH"
@@ -99,9 +99,9 @@ jobs:
             PYTORCH_ROCM_ARCH_OVERRIDE=${{ steps.gpu-arch.outputs.arch }}
             TE_COMMIT=${{ steps.te-ref.outputs.sha }}
           cache-from: |
-            type=registry,ref=rocm/megatron-lm-private:cache2
+            type=registry,ref=rocm/megatron-lm-private:cache
           cache-to: |
-            type=registry,ref=rocm/megatron-lm-private:cache2,mode=max
+            type=registry,ref=rocm/megatron-lm-private:cache,mode=max
 
       - name: Run unit tests in container
         run: |

--- a/.github/workflows/megatron-ci.yml
+++ b/.github/workflows/megatron-ci.yml
@@ -68,7 +68,7 @@ jobs:
         id: te-ref
         run: |
           set -e
-          BRANCH=release_v2.8_rocm
+          BRANCH=release_v2.6_rocm
           SHA=$(git ls-remote https://github.com/ROCm/TransformerEngine.git "refs/heads/$BRANCH" | cut -f1)
           if [ -z "$SHA" ]; then
             echo "::error::Failed to resolve TransformerEngine commit for branch $BRANCH"

--- a/.github/workflows/megatron-ci.yml
+++ b/.github/workflows/megatron-ci.yml
@@ -94,14 +94,14 @@ jobs:
           push: true
           load: true
           tags: |
-            rocm/megatron-lm-private:${{ github.sha }}
+            rocm/megatron-lm-private2:${{ github.sha }}
           build-args: |
             PYTORCH_ROCM_ARCH_OVERRIDE=${{ steps.gpu-arch.outputs.arch }}
             TE_COMMIT=${{ steps.te-ref.outputs.sha }}
           cache-from: |
-            type=registry,ref=rocm/megatron-lm-private:cache
+            type=registry,ref=rocm/megatron-lm-private2:cache
           cache-to: |
-            type=registry,ref=rocm/megatron-lm-private:cache,mode=max
+            type=registry,ref=rocm/megatron-lm-private2:cache,mode=max
 
       - name: Run unit tests in container
         run: |
@@ -120,7 +120,7 @@ jobs:
             --workdir /workspace/Megatron-LM \
             --name megatron-lm-container \
             --entrypoint /workspace/Megatron-LM/run_unit_tests.sh \
-            rocm/megatron-lm-private:${{ github.sha }}
+            rocm/megatron-lm-private2:${{ github.sha }}
 
       - name: Publish test report
         if: always()
@@ -155,6 +155,6 @@ jobs:
       - name: Cleanup Docker image
         if: always()
         run: |
-          docker image rm rocm/megatron-lm-private:${{ github.sha }} || true
+          docker image rm rocm/megatron-lm-private2:${{ github.sha }} || true
 
 

--- a/.github/workflows/megatron-ci.yml
+++ b/.github/workflows/megatron-ci.yml
@@ -68,7 +68,7 @@ jobs:
         id: te-ref
         run: |
           set -e
-          BRANCH=release_v2.6_rocm
+          BRANCH=release_v2.8_rocm
           SHA=$(git ls-remote https://github.com/ROCm/TransformerEngine.git "refs/heads/$BRANCH" | cut -f1)
           if [ -z "$SHA" ]; then
             echo "::error::Failed to resolve TransformerEngine commit for branch $BRANCH"

--- a/.github/workflows/megatron-ci.yml
+++ b/.github/workflows/megatron-ci.yml
@@ -68,7 +68,7 @@ jobs:
         id: te-ref
         run: |
           set -e
-          BRANCH=release_v2.8_rocm
+          BRANCH=sudhu/release_v2.8_rocm_cherrypicks
           SHA=$(git ls-remote https://github.com/ROCm/TransformerEngine.git "refs/heads/$BRANCH" | cut -f1)
           if [ -z "$SHA" ]; then
             echo "::error::Failed to resolve TransformerEngine commit for branch $BRANCH"

--- a/.github/workflows/megatron-ci.yml
+++ b/.github/workflows/megatron-ci.yml
@@ -94,14 +94,14 @@ jobs:
           push: true
           load: true
           tags: |
-            rocm/megatron-lm-private2:${{ github.sha }}
+            rocm/megatron-lm-private:${{ github.sha }}
           build-args: |
             PYTORCH_ROCM_ARCH_OVERRIDE=${{ steps.gpu-arch.outputs.arch }}
             TE_COMMIT=${{ steps.te-ref.outputs.sha }}
           cache-from: |
-            type=registry,ref=rocm/megatron-lm-private2:cache
+            type=registry,ref=rocm/megatron-lm-private:cache2
           cache-to: |
-            type=registry,ref=rocm/megatron-lm-private2:cache,mode=max
+            type=registry,ref=rocm/megatron-lm-private:cache2,mode=max
 
       - name: Run unit tests in container
         run: |
@@ -120,7 +120,7 @@ jobs:
             --workdir /workspace/Megatron-LM \
             --name megatron-lm-container \
             --entrypoint /workspace/Megatron-LM/run_unit_tests.sh \
-            rocm/megatron-lm-private2:${{ github.sha }}
+            rocm/megatron-lm-private:${{ github.sha }}
 
       - name: Publish test report
         if: always()
@@ -155,6 +155,6 @@ jobs:
       - name: Cleanup Docker image
         if: always()
         run: |
-          docker image rm rocm/megatron-lm-private2:${{ github.sha }} || true
+          docker image rm rocm/megatron-lm-private:${{ github.sha }} || true
 
 

--- a/.github/workflows/megatron-ci.yml
+++ b/.github/workflows/megatron-ci.yml
@@ -68,7 +68,7 @@ jobs:
         id: te-ref
         run: |
           set -e
-          BRANCH=release_v2.2_rocm
+          BRANCH=release_v2.8_rocm
           SHA=$(git ls-remote https://github.com/ROCm/TransformerEngine.git "refs/heads/$BRANCH" | cut -f1)
           if [ -z "$SHA" ]; then
             echo "::error::Failed to resolve TransformerEngine commit for branch $BRANCH"

--- a/Dockerfile_rocm.ci
+++ b/Dockerfile_rocm.ci
@@ -78,6 +78,7 @@ ARG TE_COMMIT=release_v2.2_rocm
 ENV NVTE_FRAMEWORK=pytorch
 ENV PYTORCH_ROCM_ARCH=${PYTORCH_ROCM_ARCH_OVERRIDE}
 ENV NVTE_USE_HIPBLASLT=1
+ENV NVTE_AITER_PREBUILT_BASE_URL=https://compute-artifactory.amd.com:5000/artifactory/rocm-generic-local/te-ci/aiter-prebuilts
 
 RUN git clone --recursive https://github.com/ROCm/TransformerEngine.git && \
     cd TransformerEngine && \

--- a/tests/unit_tests/a2a_overlap/test_schedule_chunk_1f1b.py
+++ b/tests/unit_tests/a2a_overlap/test_schedule_chunk_1f1b.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
 import gc
 
+from megatron.core.enums import Fp8Recipe
 import pytest
 import torch
 
@@ -95,10 +96,13 @@ class TestA2AOverlap:
 
         # create TransformerConfig
         extra_kwargs = {"moe_token_dispatcher_type": dispatcher_type}
+
         if dispatcher_type == "flex":
             extra_kwargs["moe_enable_deepep"] = True
             extra_kwargs["moe_router_dtype"] = "fp32"
         if fp8_flag is not None:
+            if fp8_flag[1] == Fp8Recipe.blockwise:
+                pytest.skip("Blockwise FP8 is not supported in ROCm")
             extra_kwargs["fp8"] = fp8_flag[0]
             extra_kwargs["fp8_recipe"] = fp8_flag[1]
         if mtp_layers > 0:

--- a/tests/unit_tests/a2a_overlap/test_schedule_layer_1f1b.py
+++ b/tests/unit_tests/a2a_overlap/test_schedule_layer_1f1b.py
@@ -414,6 +414,8 @@ class TestA2AOverlap:
             extra_kwargs["moe_enable_deepep"] = True
             extra_kwargs["moe_router_dtype"] = "fp32"
         if fp8_flag is not None:
+            if fp8_flag[1] == Fp8Recipe.blockwise:
+                pytest.skip("Blockwise FP8 is not supported in ROCm")
             extra_kwargs["fp8_recipe"] = fp8_flag[1]
             extra_kwargs["fp8"] = fp8_flag[0]
         config = get_test_config(extra_kwargs=extra_kwargs)

--- a/tests/unit_tests/a2a_overlap/test_schedule_layer_1f1b.py
+++ b/tests/unit_tests/a2a_overlap/test_schedule_layer_1f1b.py
@@ -5,6 +5,7 @@ import pytest
 import torch
 
 from megatron.core.fp8_utils import get_fp8_context
+from megatron.core.enums import Fp8Recipe
 from megatron.core.models.common.model_chunk_schedule_plan import TransformerLayerSchedulePlan
 from megatron.core.models.gpt.gpt_layer_specs import (
     get_gpt_decoder_block_spec,
@@ -361,6 +362,8 @@ class TestA2AOverlap:
             extra_kwargs["moe_enable_deepep"] = True
             extra_kwargs["moe_router_dtype"] = "fp32"
         if fp8_flag is not None:
+            if fp8_flag[1] == Fp8Recipe.blockwise:
+                pytest.skip("Blockwise FP8 is not supported in ROCm")
             extra_kwargs["fp8"] = fp8_flag[0]
             extra_kwargs["fp8_recipe"] = fp8_flag[1]
         config = get_test_config(extra_kwargs=extra_kwargs)

--- a/tests/unit_tests/dist_checkpointing/test_safe_globals.py
+++ b/tests/unit_tests/dist_checkpointing/test_safe_globals.py
@@ -34,7 +34,7 @@ class TestSafeGlobals:
     @pytest.mark.skipif(not is_torch_min_version("2.6a0"), reason="PyTorch 2.6 is required")
     def test_unsafe_globals(self, tmp_path_dist_ckpt):
         # create dummy checkpoint
-        ckpt_path = tmp_path_dist_ckpt / "test_safe_globals.pt"
+        ckpt_path = tmp_path_dist_ckpt / "test_unsafe_globals.pt"
         dummy_obj = UnsafeClass(123)
         if not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0:
             torch.save(dummy_obj, ckpt_path)

--- a/tests/unit_tests/test_fp8_param.py
+++ b/tests/unit_tests/test_fp8_param.py
@@ -26,6 +26,16 @@ from megatron.training.training import get_model, setup_model_and_optimizer
 from megatron.training.utils import get_device_arch_version
 from tests.unit_tests.test_utilities import Utils
 
+try:
+    # Check if FP8 block scaling is available.
+    from transformer_engine.pytorch.fp8 import check_fp8_block_scaling_support
+
+    fp8_block_scaling_available, reason_for_no_fp8_block_scaling = check_fp8_block_scaling_support()
+    from transformer_engine.common.recipe import Float8BlockScaling, Format
+except:
+    fp8_block_scaling_available = False
+    reason_for_no_fp8_block_scaling = "FP8 block scaled GEMM requires Hopper and CUDA >= 12.9."
+
 _SEED = 1234
 fp8_available, reason_for_no_fp8 = check_fp8_support()
 
@@ -271,10 +281,7 @@ class TestFP8Param:
         }
         self.run_test(tp_size=tp_size, recipe="tensorwise", **kwargs)
 
-    @pytest.mark.skipif(
-        get_device_arch_version() != 9, reason="blockwise is only supported on Hopper architecture"
-    )
-    @pytest.mark.skipif(not fp8_available, reason=reason_for_no_fp8)
+    @pytest.mark.skipif(not fp8_block_scaling_available, reason=reason_for_no_fp8_block_scaling)
     @pytest.mark.skipif(not is_te_min_version("2.4.0.dev0"), reason="TE 2.4.0.dev0 is required")
     @pytest.mark.parametrize("tp_size", [2])
     @pytest.mark.parametrize("dp_overlap", [(True, True)])
@@ -296,10 +303,7 @@ class TestFP8Param:
         kwargs = {"overlap_param_gather": dp_overlap[0], "overlap_grad_reduce": dp_overlap[1]}
         self.run_test(tp_size=tp_size, recipe="mxfp8", **kwargs)
 
-    @pytest.mark.skipif(
-        get_device_arch_version() != 9, reason="blockwise is only supported on Hopper architecture"
-    )
-    @pytest.mark.skipif(not fp8_available, reason=reason_for_no_fp8)
+    @pytest.mark.skipif(not fp8_block_scaling_available, reason=reason_for_no_fp8_block_scaling)
     @pytest.mark.skipif(not is_te_min_version("2.4.0.dev0"), reason="TE 2.4.0.dev0 is required")
     @pytest.mark.parametrize("tp_size", [2])
     def test_blockwise_scaling_with_first_last_layers_bf16(self, tp_size):

--- a/tests/unit_tests/test_optimizer.py
+++ b/tests/unit_tests/test_optimizer.py
@@ -26,10 +26,10 @@ try:
 except:
     fp8_block_scaling_available = False
     reason_for_no_fp8_block_scaling = "FP8 block scaled GEMM requires Hopper and CUDA >= 12.9."
-    try:
-        from transformer_engine.common.recipe import DelayedScaling
-    except:
-        delayed_scaling_available = False
+try:
+    from transformer_engine.common.recipe import DelayedScaling
+except:
+    delayed_scaling_available = False
 
 
 class Net(nn.Module):


### PR DESCRIPTION
## Motivation

This PR upgrades the CI for Megatron-LM to use TE release_v2.10, updated from currently used release_v2.2

## Technical Details

Use TE release_v2.10_rocm branch.
Disable blockwise scaling unit tests
Minor fixes.

## Test Plan

Ran unit tests on the CI with TE release_v2.10 branch

## Test Result

https://github.com/ROCm/Megatron-LM/runs/67983116928

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
