### PR TITLE
Add optional TE-native SwiGLU kernel dispatch (USE_TE_SWIGLU)

### DIFF
--- a/megatron/core/fusions/fused_bias_swiglu.py
+++ b/megatron/core/fusions/fused_bias_swiglu.py
@@ -3,7 +3,7 @@
 
 # pylint: disable=missing-function-docstring, missing-class-docstring
 
-import os
+import warnings
 
 import torch
 import torch.nn.functional as F
@@ -12,13 +12,10 @@ from megatron.core.jit import jit_fuser
 from megatron.core.utils import nvtx_decorator
 
 try:
+    import transformer_engine.pytorch  # noqa: F401 — loads shared libs needed by tex
     import transformer_engine_torch as tex
-
-    _te_swiglu_available = True
 except ImportError:
-    _te_swiglu_available = False
-
-_use_te_swiglu = _te_swiglu_available and int(os.getenv("NVTE_SWIGLU", "0"))
+    tex = None
 
 ###### BIAS SWIGLU FUSION/ NO AUTOGRAD ################
 
@@ -160,13 +157,15 @@ class SwiGLUFunction(torch.autograd.Function):
 
     @staticmethod
     @nvtx_decorator()
-    def forward(ctx, input, fp8_input_store, cpu_offload_input):
+    def forward(ctx, input, fp8_input_store, cpu_offload_input, use_te_swiglu=False):
         """Forward pass of SwiGLU activation.
 
         Args:
             ctx: Autograd context object for saving tensors for backward pass.
             input (torch.Tensor): Input tensor to apply SwiGLU to.
             fp8_input_store (bool): If True, stores intermediate values in FP8 format.
+            cpu_offload_input (bool): If True, offloads activations to CPU.
+            use_te_swiglu (bool): If True, dispatch to TE native kernel.
 
         Returns:
             torch.Tensor: Result of applying SwiGLU activation.
@@ -177,8 +176,15 @@ class SwiGLUFunction(torch.autograd.Function):
         ctx.save_for_backward(input_for_backward)
         ctx.ori_input_dtype = input.dtype
         ctx.fp8_input_store = fp8_input_store
+        if use_te_swiglu and tex is None:
+            warnings.warn(
+                "--use-te-swiglu was set but transformer_engine is not installed. "
+                "Falling back to the default fused SwiGLU implementation."
+            )
+            use_te_swiglu = False
+        ctx.use_te_swiglu = use_te_swiglu
 
-        if _use_te_swiglu:
+        if use_te_swiglu:
             return tex.swiglu(input, None)
         return swiglu(input)
 
@@ -199,11 +205,11 @@ class SwiGLUFunction(torch.autograd.Function):
         input = ctx.saved_tensors[0]
         input = input.to(ctx.ori_input_dtype) if ctx.fp8_input_store else input
 
-        if _use_te_swiglu:
+        if ctx.use_te_swiglu:
             tmp = tex.dswiglu(grad_output, input, None)
         else:
             tmp = swiglu_back(grad_output, input)
-        return tmp, None, None
+        return tmp, None, None, None
 
 
 class WeightedSwiGLUFunction(torch.autograd.Function):
@@ -224,7 +230,9 @@ class WeightedSwiGLUFunction(torch.autograd.Function):
         return tmp, wgrad, None
 
 
-def bias_swiglu_impl(input, bias, fp8_input_store=False, cpu_offload_input=False):
+def bias_swiglu_impl(
+    input, bias, fp8_input_store=False, cpu_offload_input=False, use_te_swiglu=False
+):
     """Implementation of biased SwiGLU that handles different input shapes.
 
     This function reshapes the input if necessary, applies the SwiGLU activation
@@ -236,6 +244,10 @@ def bias_swiglu_impl(input, bias, fp8_input_store=False, cpu_offload_input=False
             uses the bias-free SwiGLU variant.
         fp8_input_store (bool, optional): Whether to store intermediate values in FP8 format.
             Defaults to False.
+        cpu_offload_input (bool, optional): Whether to offload activations to CPU.
+            Defaults to False.
+        use_te_swiglu (bool, optional): Whether to dispatch to TE native SwiGLU kernel.
+            Only applies to the bias-free path. Defaults to False.
 
     Returns:
         torch.Tensor: Result of biased SwiGLU activation.
@@ -249,7 +261,9 @@ def bias_swiglu_impl(input, bias, fp8_input_store=False, cpu_offload_input=False
     if bias is not None:
         output = BiasSwiGLUFunction.apply(input, bias, fp8_input_store, cpu_offload_input)
     else:
-        output = SwiGLUFunction.apply(input, fp8_input_store, cpu_offload_input)
+        output = SwiGLUFunction.apply(
+            input, fp8_input_store, cpu_offload_input, use_te_swiglu
+        )
 
     return output if len(ori_shape) == 2 else output.view(ori_shape[0], ori_shape[1], -1)
 

--- a/megatron/core/fusions/fused_bias_swiglu.py
+++ b/megatron/core/fusions/fused_bias_swiglu.py
@@ -179,7 +179,7 @@ class SwiGLUFunction(torch.autograd.Function):
         ctx.fp8_input_store = fp8_input_store
 
         if _use_te_swiglu:
-            return tex.swiglu(input)
+            return tex.swiglu(input, None)
         return swiglu(input)
 
     @staticmethod

--- a/megatron/core/fusions/fused_bias_swiglu.py
+++ b/megatron/core/fusions/fused_bias_swiglu.py
@@ -19,7 +19,7 @@ try:
 except ImportError:
     _te_swiglu_available = False
 
-_use_te_swiglu = os.getenv("USE_TE_SWIGLU", "0") == "1"
+_use_te_swiglu = _te_swiglu_available and int(os.getenv("USE_TE_SWIGLU", "0"))
 
 ###### BIAS SWIGLU FUSION/ NO AUTOGRAD ################
 
@@ -179,7 +179,7 @@ class SwiGLUFunction(torch.autograd.Function):
         ctx.ori_input_dtype = input.dtype
         ctx.fp8_input_store = fp8_input_store
 
-        if _use_te_swiglu and _te_swiglu_available:
+        if _use_te_swiglu:
             return te.ops.SwiGLU()(input)
         return swiglu(input)
 
@@ -200,7 +200,7 @@ class SwiGLUFunction(torch.autograd.Function):
         input = ctx.saved_tensors[0]
         input = input.to(ctx.ori_input_dtype) if ctx.fp8_input_store else input
 
-        if _use_te_swiglu and _te_swiglu_available:
+        if _use_te_swiglu:
             tmp = tex.dswiglu(grad_output, input, None)
         else:
             tmp = swiglu_back(grad_output, input)

--- a/megatron/core/fusions/fused_bias_swiglu.py
+++ b/megatron/core/fusions/fused_bias_swiglu.py
@@ -3,11 +3,23 @@
 
 # pylint: disable=missing-function-docstring, missing-class-docstring
 
+import os
+
 import torch
 import torch.nn.functional as F
 
 from megatron.core.jit import jit_fuser
 from megatron.core.utils import nvtx_decorator
+
+try:
+    import transformer_engine.pytorch as te
+    import transformer_engine_torch as tex
+
+    _te_swiglu_available = True
+except ImportError:
+    _te_swiglu_available = False
+
+_use_te_swiglu = os.getenv("USE_TE_SWIGLU", "0") == "1"
 
 ###### BIAS SWIGLU FUSION/ NO AUTOGRAD ################
 
@@ -166,6 +178,9 @@ class SwiGLUFunction(torch.autograd.Function):
         ctx.save_for_backward(input_for_backward)
         ctx.ori_input_dtype = input.dtype
         ctx.fp8_input_store = fp8_input_store
+
+        if _use_te_swiglu and _te_swiglu_available:
+            return te.ops.SwiGLU()(input)
         return swiglu(input)
 
     @staticmethod
@@ -184,7 +199,11 @@ class SwiGLUFunction(torch.autograd.Function):
         """
         input = ctx.saved_tensors[0]
         input = input.to(ctx.ori_input_dtype) if ctx.fp8_input_store else input
-        tmp = swiglu_back(grad_output, input)
+
+        if _use_te_swiglu and _te_swiglu_available:
+            tmp = tex.dswiglu(grad_output, input, None)
+        else:
+            tmp = swiglu_back(grad_output, input)
         return tmp, None, None
 
 

--- a/megatron/core/fusions/fused_bias_swiglu.py
+++ b/megatron/core/fusions/fused_bias_swiglu.py
@@ -12,7 +12,6 @@ from megatron.core.jit import jit_fuser
 from megatron.core.utils import nvtx_decorator
 
 try:
-    import transformer_engine.pytorch as te
     import transformer_engine_torch as tex
 
     _te_swiglu_available = True
@@ -180,7 +179,7 @@ class SwiGLUFunction(torch.autograd.Function):
         ctx.fp8_input_store = fp8_input_store
 
         if _use_te_swiglu:
-            return te.ops.SwiGLU()(input)
+            return tex.swiglu(input)
         return swiglu(input)
 
     @staticmethod

--- a/megatron/core/fusions/fused_bias_swiglu.py
+++ b/megatron/core/fusions/fused_bias_swiglu.py
@@ -18,7 +18,7 @@ try:
 except ImportError:
     _te_swiglu_available = False
 
-_use_te_swiglu = _te_swiglu_available and int(os.getenv("USE_TE_SWIGLU", "0"))
+_use_te_swiglu = _te_swiglu_available and int(os.getenv("NVTE_SWIGLU", "0"))
 
 ###### BIAS SWIGLU FUSION/ NO AUTOGRAD ################
 

--- a/megatron/core/transformer/mlp.py
+++ b/megatron/core/transformer/mlp.py
@@ -212,6 +212,7 @@ class MLP(MegatronModule):
                         self.config.cpu_offloading
                         and self.config.cpu_offloading_activations
                         and HAVE_TE,
+                        self.config.use_te_swiglu,
                     )
                 else:
                     raise ValueError("Only support fusion of gelu and swiglu")

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -679,6 +679,10 @@ class TransformerConfig(ModelParallelConfig):
     use_te_activation_func: bool = False
     """Whether to use ffn activation functions implemented by TransformerEngine"""
 
+    use_te_swiglu: bool = False
+    """Whether to use Transformer Engine native SwiGLU kernel (tex.swiglu/tex.dswiglu)
+    in the bias-free SwiGLU activation path."""
+
     use_te_rng_tracker: bool = False
     """ Whether to use the TE or MCore version of the RNG tracker. """
 

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2334,6 +2334,9 @@ def _add_training_args(parser):
                        help='The communicator group names to use high priority streams.')
     group.add_argument('--use-te-activation-func', action='store_true',
                        help='Use activation function kernel from Transformer Engine in MLP module.')
+    group.add_argument('--use-te-swiglu', action='store_true',
+                       help='Use Transformer Engine native SwiGLU kernel in the bias-free '
+                            'SwiGLU activation path. Requires transformer_engine_torch.')
 
     return parser
 

--- a/tests/unit_tests/fusions/test_swiglu_fusion.py
+++ b/tests/unit_tests/fusions/test_swiglu_fusion.py
@@ -1,7 +1,18 @@
+import os
+import unittest.mock
+
 import pytest
 import torch
 
 from megatron.core.fusions.fused_bias_swiglu import bias_swiglu_impl, weighted_bias_swiglu_impl
+
+
+def _te_swiglu_available():
+    try:
+        import transformer_engine_torch  # noqa: F401
+        return True
+    except ImportError:
+        return False
 
 
 @pytest.mark.parametrize("input_dtype", [torch.bfloat16, torch.float32])
@@ -39,3 +50,38 @@ def test_weighted_bias_swiglu(input_dtype):
     assert weights_2.grad.dtype == weights.grad.dtype
     if input_dtype == torch.float32:
         assert torch.allclose(weights.grad, weights_2.grad, **tols)
+
+
+@pytest.mark.skipif(not _te_swiglu_available(), reason="transformer_engine_torch not installed")
+@pytest.mark.parametrize("input_dtype", [torch.bfloat16, torch.float32])
+@pytest.mark.parametrize("shape", [(16, 64), (4, 8, 64)])
+def test_te_swiglu_forward_backward(input_dtype, shape):
+    """Verify NVTE_SWIGLU=1 (TE kernel) matches the default fused path for SwiGLUFunction."""
+    if input_dtype == torch.float32:
+        tols = dict(rtol=1.0e-5, atol=1.0e-5)
+    else:
+        tols = dict(rtol=2.0e-2, atol=1.0e-3)
+
+    x = torch.randn(shape, dtype=input_dtype, device="cuda")
+    grad_out_shape = list(shape)
+    grad_out_shape[-1] //= 2
+    grad_out = torch.randn(grad_out_shape, dtype=input_dtype, device="cuda")
+
+    x_ref = x.clone().detach().requires_grad_(True)
+    y_ref = bias_swiglu_impl(x_ref, None)
+    y_ref.backward(grad_out)
+
+    import megatron.core.fusions.fused_bias_swiglu as _mod
+    with unittest.mock.patch.object(_mod, "_use_te_swiglu", True):
+        x_te = x.clone().detach().requires_grad_(True)
+        y_te = bias_swiglu_impl(x_te, None)
+        y_te.backward(grad_out)
+
+    assert y_te.shape == y_ref.shape
+    assert torch.allclose(y_te, y_ref, **tols), (
+        f"Forward mismatch: max diff = {(y_te - y_ref).abs().max().item()}"
+    )
+    assert x_te.grad.shape == x_ref.grad.shape
+    assert torch.allclose(x_te.grad, x_ref.grad, **tols), (
+        f"Backward mismatch: max diff = {(x_te.grad - x_ref.grad).abs().max().item()}"
+    )

--- a/tests/unit_tests/fusions/test_swiglu_fusion.py
+++ b/tests/unit_tests/fusions/test_swiglu_fusion.py
@@ -1,6 +1,3 @@
-import os
-import unittest.mock
-
 import pytest
 import torch
 
@@ -56,7 +53,7 @@ def test_weighted_bias_swiglu(input_dtype):
 @pytest.mark.parametrize("input_dtype", [torch.bfloat16, torch.float32])
 @pytest.mark.parametrize("shape", [(16, 64), (4, 8, 64)])
 def test_te_swiglu_forward_backward(input_dtype, shape):
-    """Verify NVTE_SWIGLU=1 (TE kernel) matches the default fused path for SwiGLUFunction."""
+    """Verify use_te_swiglu=True (TE kernel) matches the default fused path."""
     if input_dtype == torch.float32:
         tols = dict(rtol=1.0e-5, atol=1.0e-5)
     else:
@@ -71,11 +68,9 @@ def test_te_swiglu_forward_backward(input_dtype, shape):
     y_ref = bias_swiglu_impl(x_ref, None)
     y_ref.backward(grad_out)
 
-    import megatron.core.fusions.fused_bias_swiglu as _mod
-    with unittest.mock.patch.object(_mod, "_use_te_swiglu", True):
-        x_te = x.clone().detach().requires_grad_(True)
-        y_te = bias_swiglu_impl(x_te, None)
-        y_te.backward(grad_out)
+    x_te = x.clone().detach().requires_grad_(True)
+    y_te = bias_swiglu_impl(x_te, None, use_te_swiglu=True)
+    y_te.backward(grad_out)
 
     assert y_te.shape == y_ref.shape
     assert torch.allclose(y_te, y_ref, **tols), (


### PR DESCRIPTION
## Summary

- Adds opt-in dispatch to Transformer Engine's native SwiGLU kernel in `SwiGLUFunction` (forward: `te.ops.SwiGLU()`, backward: `tex.dswiglu()`)
- Enabled via `USE_TE_SWIGLU=1` env var; disabled by default

Made with [Cursor](https://cursor.com)