### PR TITLE
Enhance Dockerfile and training scripts for improved compatibility and performance

### DIFF
--- a/Dockerfile_rocm.ci
+++ b/Dockerfile_rocm.ci
@@ -12,6 +12,16 @@ RUN mkdir -p $WORKSPACE_DIR
 RUN mkdir -p ${STAGE_DIR}
 WORKDIR $WORKSPACE_DIR
 
+# Check python3 version and install respective python3-dev
+RUN PY3_VER="$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')" && \
+    if apt-cache show "python${PY3_VER}-dev" >/dev/null 2>&1; then \
+        apt-get install -y --no-install-recommends "python${PY3_VER}-dev"; \
+        # Overwrite python3-config to point to the correct version to prevent mismatch during Megatron-DeepSpeed build
+        ln -sf /usr/bin/python${PY3_VER}-config /usr/bin/python3-config; \
+    else \
+        apt-get install -y --no-install-recommends python3-dev; \
+    fi
+
 RUN pip3 install \
 scipy \
 wheel \

--- a/examples/deepseek_v2/train_deepseekv2.sh
+++ b/examples/deepseek_v2/train_deepseekv2.sh
@@ -19,7 +19,12 @@ echo $CURRENT_DIR
 export GPU_MAX_HW_QUEUES=${GPU_MAX_HW_QUEUES:-2}
 export TORCH_NCCL_HIGH_PRIORITY=${TORCH_NCCL_HIGH_PRIORITY:-1}
 export NCCL_CHECKS_DISABLE=${NCCL_CHECKS_DISABLE:-1}
-NCCL_IB_HCA_LIST=$(rdma link -j | python3 -c "import sys, json; links=json.load(sys.stdin);names=[links[i]['ifname'] for i in range(8)]; print(*names,sep=',')")
+NCCL_IB_HCA_LIST=$(rdma link -j 2>/dev/null | python3 -c "import json, sys
+try:
+    links = json.load(sys.stdin)
+    print(*[links[i][\"ifname\"] for i in range(min(8, len(links)))], sep=',')
+except Exception:
+    pass") || NCCL_IB_HCA_LIST=""
 export NCCL_IB_HCA=${NCCL_IB_HCA:-$NCCL_IB_HCA_LIST}
 export NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX:-3}
 export NCCL_CROSS_NIC=${NCCL_CROSS_NIC:-0}

--- a/examples/deepseek_v3/train_deepseekv3.sh
+++ b/examples/deepseek_v3/train_deepseekv3.sh
@@ -22,7 +22,12 @@ echo ""
 export GPU_MAX_HW_QUEUES=${GPU_MAX_HW_QUEUES:-2}
 export TORCH_NCCL_HIGH_PRIORITY=${TORCH_NCCL_HIGH_PRIORITY:-1}
 export NCCL_CHECKS_DISABLE=${NCCL_CHECKS_DISABLE:-1}
-NCCL_IB_HCA_LIST=$(rdma link -j | python3 -c "import sys, json; links=json.load(sys.stdin);names=[links[i]['ifname'] for i in range(8)]; print(*names,sep=',')")
+NCCL_IB_HCA_LIST=$(rdma link -j 2>/dev/null | python3 -c "import json, sys
+try:
+    links = json.load(sys.stdin)
+    print(*[links[i][\"ifname\"] for i in range(min(8, len(links)))], sep=',')
+except Exception:
+    pass") || NCCL_IB_HCA_LIST=""
 export NCCL_IB_HCA=${NCCL_IB_HCA:-$NCCL_IB_HCA_LIST}
 export NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX:-3}
 export NCCL_CROSS_NIC=${NCCL_CROSS_NIC:-0}

--- a/examples/llama/train_llama2.sh
+++ b/examples/llama/train_llama2.sh
@@ -11,7 +11,12 @@
 export GPU_MAX_HW_QUEUES=${GPU_MAX_HW_QUEUES:-2}
 export TORCH_NCCL_HIGH_PRIORITY=${TORCH_NCCL_HIGH_PRIORITY:-1}
 export NCCL_CHECKS_DISABLE=${NCCL_CHECKS_DISABLE:-1}
-NCCL_IB_HCA_LIST=$(rdma link -j | python3 -c "import sys, json; links=json.load(sys.stdin);names=[links[i]['ifname'] for i in range(8)]; print(*names,sep=',')")
+NCCL_IB_HCA_LIST=$(rdma link -j 2>/dev/null | python3 -c "import json, sys
+try:
+    links = json.load(sys.stdin)
+    print(*[links[i][\"ifname\"] for i in range(min(8, len(links)))], sep=',')
+except Exception:
+    pass") || NCCL_IB_HCA_LIST=""
 export NCCL_IB_HCA=${NCCL_IB_HCA:-$NCCL_IB_HCA_LIST}
 export NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX:-3}
 export NCCL_CROSS_NIC=${NCCL_CROSS_NIC:-0}
@@ -36,7 +41,7 @@ TIME_STAMP=$(date +"%Y-%m-%d_%H-%M-%S")
 EXP_NAME="${EXP_NAME:-perf}"
 
 TEE_OUTPUT="${TEE_OUTPUT:-1}"
-USE_FLASH_ATTN="${USE_FLASH_ATTN:-1}"
+USE_FLASH_ATTN="${USE_FLASH_ATTN:-0}"
 NO_TRAINING="${NO_TRAINING:-0}" # NO_TRAINING=1: for computing metrics only
 ENABLE_PROFILING="${ENABLE_PROFILING:-0}" #enable pytorch profiling
 echo "NO_TRAINING=$NO_TRAINING"
@@ -314,6 +319,8 @@ fi
 
 if [ "$USE_FLASH_ATTN" -eq 1 ]; then
     EXTRA_ARGS="$EXTRA_ARGS --use-flash-attn"
+else
+    EXTRA_ARGS="$EXTRA_ARGS --attention-backend fused"
 fi
 
 if [ "$SEQ_PARALLEL" -eq 1 ]; then

--- a/examples/llama/train_llama3.sh
+++ b/examples/llama/train_llama3.sh
@@ -10,7 +10,12 @@
 export GPU_MAX_HW_QUEUES=${GPU_MAX_HW_QUEUES:-2}
 export TORCH_NCCL_HIGH_PRIORITY=${TORCH_NCCL_HIGH_PRIORITY:-1}
 export NCCL_CHECKS_DISABLE=${NCCL_CHECKS_DISABLE:-1}
-NCCL_IB_HCA_LIST=$(rdma link -j | python3 -c "import sys, json; links=json.load(sys.stdin);names=[links[i]['ifname'] for i in range(8)]; print(*names,sep=',')")
+NCCL_IB_HCA_LIST=$(rdma link -j 2>/dev/null | python3 -c "import json, sys
+try:
+    links = json.load(sys.stdin)
+    print(*[links[i][\"ifname\"] for i in range(min(8, len(links)))], sep=',')
+except Exception:
+    pass") || NCCL_IB_HCA_LIST=""
 export NCCL_IB_HCA=${NCCL_IB_HCA:-$NCCL_IB_HCA_LIST}
 export NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX:-3}
 export NCCL_CROSS_NIC=${NCCL_CROSS_NIC:-0}
@@ -35,7 +40,7 @@ TIME_STAMP=$(date +"%Y-%m-%d_%H-%M-%S")
 EXP_NAME="${EXP_NAME:-perf}"
 
 TEE_OUTPUT="${TEE_OUTPUT:-1}"
-USE_FLASH_ATTN="${USE_FLASH_ATTN:-1}"
+USE_FLASH_ATTN="${USE_FLASH_ATTN:-0}"
 NO_TRAINING="${NO_TRAINING:-0}" # NO_TRAINING=1: for computing metrics only
 ENABLE_PROFILING="${ENABLE_PROFILING:-0}" #enable pytorch profiling
 echo "NO_TRAINING=$NO_TRAINING"
@@ -295,6 +300,8 @@ fi
 
 if [ "$USE_FLASH_ATTN" -eq 1 ]; then
     EXTRA_ARGS="$EXTRA_ARGS --use-flash-attn"
+else
+    EXTRA_ARGS="$EXTRA_ARGS --attention-backend fused"
 fi
 
 if [ "$SEQ_PARALLEL" -eq 1 ]; then

--- a/examples/mixtral/train_mixtral_moe.sh
+++ b/examples/mixtral/train_mixtral_moe.sh
@@ -3,7 +3,12 @@
 export GPU_MAX_HW_QUEUES=${GPU_MAX_HW_QUEUES:-2}
 export TORCH_NCCL_HIGH_PRIORITY=${TORCH_NCCL_HIGH_PRIORITY:-1}
 export NCCL_CHECKS_DISABLE=${NCCL_CHECKS_DISABLE:-1}
-NCCL_IB_HCA_LIST=$(rdma link -j | python3 -c "import sys, json; links=json.load(sys.stdin);names=[links[i]['ifname'] for i in range(8)]; print(*names,sep=',')")
+NCCL_IB_HCA_LIST=$(rdma link -j 2>/dev/null | python3 -c "import json, sys
+try:
+    links = json.load(sys.stdin)
+    print(*[links[i][\"ifname\"] for i in range(min(8, len(links)))], sep=',')
+except Exception:
+    pass") || NCCL_IB_HCA_LIST=""
 export NCCL_IB_HCA=${NCCL_IB_HCA:-$NCCL_IB_HCA_LIST}
 export NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX:-3}
 export NCCL_CROSS_NIC=${NCCL_CROSS_NIC:-0}

--- a/examples/qwen/train_qwen2.sh
+++ b/examples/qwen/train_qwen2.sh
@@ -36,7 +36,7 @@ TIME_STAMP=$(date +"%Y-%m-%d_%H-%M-%S")
 EXP_NAME="${EXP_NAME:-perf}"
 
 TEE_OUTPUT="${TEE_OUTPUT:-1}"
-USE_FLASH_ATTN="${USE_FLASH_ATTN:-1}"
+USE_FLASH_ATTN="${USE_FLASH_ATTN:-0}"
 NO_TRAINING="${NO_TRAINING:-0}" # NO_TRAINING=1: for computing metrics only
 ENABLE_PROFILING="${ENABLE_PROFILING:-0}" #enable pytorch profiling
 ENABLE_ROPE="${ENABLE_ROPE:-1}"
@@ -259,6 +259,8 @@ fi
 
 if [ "$USE_FLASH_ATTN" -eq 1 ]; then
 EXTRA_ARGS="$EXTRA_ARGS --use-flash-attn"
+else
+EXTRA_ARGS="$EXTRA_ARGS --attention-backend fused"
 fi
 
 if [ "$SEQ_PARALLEL" -eq 1 ]; then


### PR DESCRIPTION
Enhance Dockerfile and training scripts for improved compatibility and error handling

- Added dynamic installation of python3-dev based on the detected Python version in Dockerfile.
- Updated NCCL_IB_HCA_LIST retrieval in training scripts to handle exceptions and ensure compatibility with varying RDMA link outputs.
- Set USE_FLASH_ATTN to 0 by default in multiple training scripts and set attention backend option to fused for better performance.

## Motivation

Python headers vs runtime: Images often ship a newer python3 (e.g. 3.11) while /usr/bin/python3-config still targets an older minor (e.g. 3.10). That mismatch breaks native extension builds (wrong EXT_SUFFIX, wrong include paths) for dataset helpers and similar wheels.
RDMA / NCCL env: Example scripts assumed rdma link -j always exists, always returns valid JSON, and always had at least eight links. On single-node CPU-only or minimal hosts, that produced shell noise, JSONDecodeError, or index errors and could abort the script before training.
Flash attention defaults: Defaulting to FlashAttention shows reduced performance compared to fused attention. Hence, this PR makes the default attention-backend as fused.

## Test Plan
Run the training script individually to ensure the correctness.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
