### PR TITLE
Add distributed barrier handling in tmp_path_dist_ckpt fixture and CI fixes

### DIFF
--- a/.github/workflows/megatron-ci.yml
+++ b/.github/workflows/megatron-ci.yml
@@ -92,7 +92,9 @@ jobs:
           context: .
           file: ./Dockerfile_rocm.ci
           push: true
-          load: true
+          # Also write image to disk so `docker run` does not need `docker pull`.
+          # On some runners dockerd cannot reach auth.docker.io (timeout); BuildKit push may still work.
+          outputs: type=docker,dest=${{ runner.temp }}/megatron-ci-image.tar
           tags: |
             rocm/megatron-lm-private:${{ github.sha }}
           build-args: |
@@ -102,6 +104,9 @@ jobs:
             type=registry,ref=rocm/megatron-lm-private:cache
           cache-to: |
             type=registry,ref=rocm/megatron-lm-private:cache,mode=max
+
+      - name: Load image for docker run
+        run: docker load -i "${{ runner.temp }}/megatron-ci-image.tar"
 
       - name: Run unit tests in container
         run: |
@@ -156,5 +161,5 @@ jobs:
         if: always()
         run: |
           docker image rm rocm/megatron-lm-private:${{ github.sha }} || true
-
+          rm -f "${{ runner.temp }}/megatron-ci-image.tar"
 

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -70,9 +70,13 @@ def tmp_path_dist_ckpt(tmp_path_factory) -> Path:
     if Utils.rank == 0:
         with TempNamedDir(tmp_dir, sync=False):
             yield tmp_dir
+            if torch.distributed.is_initialized():
+                torch.distributed.barrier()
 
     else:
         yield tmp_dir
+        if torch.distributed.is_initialized():
+            torch.distributed.barrier()
 
 
 @pytest.fixture(scope="session", autouse=True)


### PR DESCRIPTION
1) Add distributed barrier handling in tmp_path_dist_ckpt fixture to ensure synchronization across ranks in unit tests.
2) Fixes CI issue ERROR: error writing layer blob: failed to copy.

## Motivation

To fix test_safe_globals.py test where without barriers, rank0 deletes the tmp dir while other ranks are still working on it.
To fix a flaky CI issue by loading from the local disk itself.

## Technical Details
conftest.py change:
Rank 0 is the one to create and delete the temporary directory and it may delete the directory while other ranks are still working on the temporary directory which causes issues. Adding barrier sync helps resolve this.

CI Issue:
```
ERROR: error writing layer blob: failed to copy: unexpected status from PUT request to registry 400 Bad request

exporting to image
pushing layers 31.3s done
CANCELED
------
> exporting cache to registry:
------
ERROR: failed to build: failed to solve: error writing layer blob: failed to copy: unexpected status from PUT request to registry 400 Bad request
Error: buildx failed with: ERROR: failed to build: failed to solve: error writing layer blob: failed to copy: unexpected status from PUT request.

```
having put and load at the same time seems to cause flaky issues, removing load and loading from the disk fixes the issue.

## Test Plan

Run CI end to end.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
