### PR TITLE
MXFP8 training fixes for Megatron-FSDP, Torch-FSDP, MoE, FP8 Parameter initialization

### DIFF
--- a/examples/llama/train_llama2.sh
+++ b/examples/llama/train_llama2.sh
@@ -65,7 +65,7 @@ else
 fi
 
 MODEL_SIZE="${MODEL_SIZE:-70}"
-TP="${TP:-8}"
+TP="${TP:-1}"
 PP="${PP:-1}"
 CP="${CP:-1}"
 MBS="${MBS:-1}"
@@ -349,16 +349,11 @@ if [ "$TE_FP8" -eq 1 ]; then
             --attention-softmax-in-fp32 \
         "
     elif [ "$TE_FP8_RECIPE" == "mxfp8" ]; then
-        if [ "$MEGATRON_FSDP" -eq 1 ]; then
-            EXTRA_ARGS="$EXTRA_ARGS --fp8-recipe=mxfp8 \
-                --fp8-format=e4m3 \
-            "
-            # TE does not enable mxfp8 by default
-            export NVTE_ROCM_ENABLE_MXFP8=1
-        else 
-            echo "Error: Llama2 supports MXFP8 only for MEGATRON_FSDP."
-            exit
-        fi
+        EXTRA_ARGS="$EXTRA_ARGS --fp8-recipe=mxfp8 \
+            --fp8-format=e4m3 \
+        "
+        # TE does not enable mxfp8 by default
+        export NVTE_ROCM_ENABLE_MXFP8=1
         
     elif [ "$TE_FP8_RECIPE" == "tensorwise" ]; then
         EXTRA_ARGS="$EXTRA_ARGS --fp8-recipe=tensorwise \
@@ -370,11 +365,15 @@ if [ "$TE_FP8" -eq 1 ]; then
     fi
 
     if [ "$FP8_PARAM_GATHER" -eq 1 ]; then
-        if [ "$TE_FP8_RECIPE" != "mxfp8" ]; then
-            EXTRA_ARGS="$EXTRA_ARGS --fp8-param-gather"
-        else
-            echo "Error: For Llama2 FP8_PARAM_GATHER and MXFP8 cannot be currently used together."
-            exit
+        EXTRA_ARGS="$EXTRA_ARGS --fp8-param-gather"
+
+        # MXFP8 + DDP path: TE does not implement `replace_raw_data` for MXFP8Tensor,
+        # so the default `_ParamAndGradBuffer` storage swap fails. Reusing the grad
+        # buffer for the MXFP8 param all-gather sidesteps that path. The FSDP and
+        # Megatron-FSDP paths handle MXFP8 param all-gather natively in TE and do
+        # not need this workaround.
+        if [ "$TE_FP8_RECIPE" == "mxfp8" ] && [ "$FSDP" -ne 1 ] && [ "$MEGATRON_FSDP" -ne 1 ]; then
+            EXTRA_ARGS="$EXTRA_ARGS --reuse-grad-buf-for-mxfp8-param-ag"
         fi
     fi
 

--- a/examples/llama/train_llama3.sh
+++ b/examples/llama/train_llama3.sh
@@ -345,11 +345,15 @@ if [ "$TE_FP8" -eq 1 ]; then
     fi
 
     if [ "$FP8_PARAM_GATHER" -eq 1 ]; then
-        if [ "$TE_FP8_RECIPE" == "mxfp8" ]  && [ "$FSDP" -eq 1 ]; then
-            EXTRA_ARGS="$EXTRA_ARGS --fp8-param-gather"
-        else
-            echo "Error: For Llama3 FP8_PARAM_GATHER and MXFP8 cannot be currently used together, unless FSDP=1"
-            exit
+        EXTRA_ARGS="$EXTRA_ARGS --fp8-param-gather"
+
+        # MXFP8 + DDP path: TE does not implement `replace_raw_data` for MXFP8Tensor,
+        # so the default `_ParamAndGradBuffer` storage swap fails. Reusing the grad
+        # buffer for the MXFP8 param all-gather sidesteps that path. The FSDP and
+        # Megatron-FSDP paths handle MXFP8 param all-gather natively in TE and do
+        # not need this workaround.
+        if [ "$TE_FP8_RECIPE" == "mxfp8" ] && [ "$FSDP" -ne 1 ] && [ "$MEGATRON_FSDP" -ne 1 ]; then
+            EXTRA_ARGS="$EXTRA_ARGS --reuse-grad-buf-for-mxfp8-param-ag"
         fi
     fi
 

--- a/megatron/core/distributed/data_parallel_base.py
+++ b/megatron/core/distributed/data_parallel_base.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
 
 from contextlib import contextmanager
+from typing import Optional
 
 import torch
 
@@ -46,7 +47,7 @@ class _BaseDataParallel(MegatronModule):
         """Scale all gradients inside the buffers by `scaling_factor`."""
         pass
 
-    def finish_grad_sync(self):
+    def finish_grad_sync(self, force_all_reduce: Optional[bool] = False):
         """
         Finishes grad sync (all-reduce or reduce-scatter) communication operations
         for all model gradients.
@@ -54,6 +55,12 @@ class _BaseDataParallel(MegatronModule):
         When overlap_grad_reduce is set to True, waits for asynchronous communication
         calls to complete. When overlap_grad_reduce is set to False, calls synchronous
         communication ops.
+
+        NOTE: ``force_all_reduce`` is included in the signature to maintain API
+        compatibility with subclasses (e.g. ``DistributedDataParallel`` and
+        ``MegatronFSDP``) so that callers in ``finalize_model_grads`` can pass
+        the kwarg uniformly to any data-parallel wrapper, including ones that
+        don't override this method (e.g. ``TorchFullyShardedDataParallel``).
         """
         pass
 

--- a/megatron/core/distributed/torch_fully_sharded_data_parallel.py
+++ b/megatron/core/distributed/torch_fully_sharded_data_parallel.py
@@ -91,11 +91,20 @@ class TorchFullyShardedDataParallel(_BaseDataParallel):
             for name, param in module.named_parameters():
                 attrs = vars(param)
                 if is_float8tensor(param):
-                    # disable fp8 transpose cache and perform transposing fp8 weights
+                    # Disable fp8 transpose cache and perform transposing fp8 weights
                     # at each micro-batch because torch-FSDP doesn't recognize the
-                    # micro-batch id, thus removing unnecessary memory stores
-                    attrs['_fp8_attrs']['transpose_invalid'] = False
-                    del attrs['_fp8_attrs']['transpose']
+                    # micro-batch id, thus removing unnecessary memory stores.
+                    #
+                    # In TE 1.x the transpose-cache state lives in a nested dict
+                    # `param._fp8_attrs`; in TE 2.x it was promoted to flat
+                    # attributes (`_transpose` / `_transpose_invalid`) on
+                    # Float8TensorStorage. Handle both layouts.
+                    if '_fp8_attrs' in attrs:
+                        attrs['_fp8_attrs']['transpose_invalid'] = False
+                        attrs['_fp8_attrs'].pop('transpose', None)
+                    else:
+                        attrs['_transpose_invalid'] = False
+                        # `_transpose` itself is dropped via `_SKIP_KEYS` below.
                 custom_attrs[name] = {k: v for k, v in attrs.items()}
                 for k in _SKIP_KEYS:
                     custom_attrs[name].pop(k, None)

--- a/megatron/core/fp8_utils.py
+++ b/megatron/core/fp8_utils.py
@@ -168,7 +168,8 @@ def _get_custom_recipe(quantizer_factory_python_path: str) -> Union[Fp8Recipe, F
 def get_fp8_align_size(fp8_recipe: Fp8Recipe) -> int:
     """Get the alignment size required for fp8 GEMM."""
     if fp8_recipe == Fp8Recipe.mxfp8:
-        return 32
+        # HipblasLT requires 128 aligned Tensors for MXFP8.
+        return 128
     else:
         return 16
 

--- a/megatron/core/transformer/multi_latent_attention.py
+++ b/megatron/core/transformer/multi_latent_attention.py
@@ -29,6 +29,8 @@ except ImportError:
 
 
 from megatron.core import tensor_parallel
+from megatron.core.enums import Fp8Recipe
+from megatron.core.fp8_utils import get_fp8_align_size
 from megatron.core.models.common.embeddings import (
     RotaryEmbedding,
     YarnRotaryEmbedding,
@@ -542,10 +544,19 @@ class MLASelfAttention(MultiLatentAttention):
         else:
             raise ValueError(f"Unsupported linear_kv_down_proj: {submodules.linear_kv_down_proj}")
 
+        kv_down_proj_out_size = self.config.kv_lora_rank + self.config.qk_pos_emb_head_dim
+        self.kv_down_proj_mxfp8_padding = 0
+        if self.config.fp8 and self.config.fp8_recipe == Fp8Recipe.mxfp8:
+            align = get_fp8_align_size(Fp8Recipe.mxfp8)
+            remainder = kv_down_proj_out_size % align
+            if remainder != 0:
+                self.kv_down_proj_mxfp8_padding = align - remainder
+                kv_down_proj_out_size += self.kv_down_proj_mxfp8_padding
+
         self.linear_kv_down_proj = build_module(
             submodules.linear_kv_down_proj,
             self.config.hidden_size,
-            self.config.kv_lora_rank + self.config.qk_pos_emb_head_dim,
+            kv_down_proj_out_size,
             config=self.config,
             init_method=self.config.init_method,
             bias=False,
@@ -680,28 +691,35 @@ class MLASelfAttention(MultiLatentAttention):
             q_compressed = hidden_states
 
         # if linear_kv_down_proj is ColumnParallelLinear:
-        #     kv_combined: [s, b, (kv_lora_rank + qk_pos_emb_head_dim) / TP]
+        #     kv_combined: [s, b, (kv_down_proj_out_size) / TP]
         # elif linear_kv_down_proj is Linear:
-        #     kv_combined: [s / TP, b, (kv_lora_rank + qk_pos_emb_head_dim)]
+        #     kv_combined: [s / TP, b, kv_down_proj_out_size]
         kv_combined, _ = self.linear_kv_down_proj(hidden_states)
-        if kv_combined.size(-1) != self.config.kv_lora_rank + self.config.qk_pos_emb_head_dim:
-            # kv_combined: [s, b, (kv_lora_rank + qk_pos_emb_head_dim)]
+        kv_down_proj_out_size = (
+            self.config.kv_lora_rank
+            + self.config.qk_pos_emb_head_dim
+            + self.kv_down_proj_mxfp8_padding
+        )
+        kv_is_tp_sharded = kv_combined.size(-1) != kv_down_proj_out_size
+        if kv_is_tp_sharded:
             kv_combined = gather_from_tensor_model_parallel_region(kv_combined)
-            # kv_compressed:[s, b, kv_lora_rank], k_pos_emb: [s, b, qk_pos_emb_head_dim]
-            kv_compressed, k_pos_emb = torch.split(
-                kv_combined, [self.config.kv_lora_rank, self.config.qk_pos_emb_head_dim], dim=-1
-            )
-            if self.config.sequence_parallel:
-                # kv_compressed:[s / TP, b, kv_lora_rank]
-                kv_compressed = scatter_to_sequence_parallel_region(kv_compressed)
-        else:
-            # kv_compressed:[s / TP, b, kv_lora_rank], k_pos_emb: [s / TP, b, qk_pos_emb_head_dim]
-            kv_compressed, k_pos_emb = torch.split(
-                kv_combined, [self.config.kv_lora_rank, self.config.qk_pos_emb_head_dim], dim=-1
-            )
-            if get_pg_size(self.tp_group) > 1 and self.config.sequence_parallel:
-                # k_pos_emb: [s, b, qk_pos_emb_head_dim]
-                k_pos_emb = gather_from_sequence_parallel_region(k_pos_emb, group=self.tp_group)
+        if self.kv_down_proj_mxfp8_padding > 0:
+            kv_combined = kv_combined[
+                ..., : self.config.kv_lora_rank + self.config.qk_pos_emb_head_dim
+            ]
+        # kv_compressed: [..., kv_lora_rank], k_pos_emb: [..., qk_pos_emb_head_dim]
+        kv_compressed, k_pos_emb = torch.split(
+            kv_combined, [self.config.kv_lora_rank, self.config.qk_pos_emb_head_dim], dim=-1
+        )
+        if kv_is_tp_sharded and self.config.sequence_parallel:
+            kv_compressed = scatter_to_sequence_parallel_region(kv_compressed)
+        elif (
+            not kv_is_tp_sharded
+            and get_pg_size(self.tp_group) > 1
+            and self.config.sequence_parallel
+        ):
+            # k_pos_emb: [s, b, qk_pos_emb_head_dim]
+            k_pos_emb = gather_from_sequence_parallel_region(k_pos_emb, group=self.tp_group)
 
         if packed_seq_params is not None:
             # If sequence packing, TE expect [t, h, d] shaped qkv input.

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -718,11 +718,11 @@ def validate_args(args, defaults={}):
         assert os.environ.get('CUDA_DEVICE_MAX_CONNECTIONS') != "1", \
             'FSDP always requires CUDA_DEVICE_MAX_CONNECTIONS value large than one'
 
-        if args.fp8_param_gather and is_te_min_version("2.0.0"):
+        if args.fp8_param_gather and not is_te_min_version("2.12.0.dev0"):
             args.fp8_param_gather = False
             warn_rank_0(
-                'FSDP2 FP8 param gather is not supported yet in TE 2.0, will fallback to bf16'
-                'all_gather instead, turning off fp8_param_gather',
+                'FSDP2 FP8 param gather requires Transformer Engine >= 2.12.0, '
+                'will fallback to bf16 all_gather instead, turning off fp8_param_gather',
                 args.rank,
             )
         if args.fp4_param and not is_te_min_version("2.7.0.dev0"):


### PR DESCRIPTION
Changes:

- _BaseDataParallel.finish_grad_sync: accept force_all_reduce kwarg
- torch_fully_sharded_data_parallel: TE 2.x _fp8_attrs flat-attr fallback; drop debug print
- arguments: gate FSDP2 fp8_param_gather warning on TE >= 2.12, not 2.0
- fp8_utils: MXFP8 align size 32 -> 128 for HipBLASLt
- llama2/llama3 train scripts: drop MXFP8 guards; auto-add --reuse-grad-buf-for-mxfp8-param-ag when MXFP8 + fp8-param-gather without FSDP
- MLA: Ensure the proj value are aligned with mxfp8 align size.

# What does this PR do?
Fix issues with MXFP8 training in Megatron-LM

Fixes: [#15425](https://github.com/ROCm/frameworks-internal/issues/15425)
[#15420](https://github.com/ROCm/frameworks-internal/issues/15420)
