### PR TITLE
examples/qwen: make NCCL_IB_HCA portable and overridable

### DIFF
--- a/examples/qwen/train_qwen2.sh
+++ b/examples/qwen/train_qwen2.sh
@@ -7,17 +7,23 @@
 # set -x
 
 # set envs 
-export GPU_MAX_HW_QUEUES=2
-export TORCH_NCCL_HIGH_PRIORITY=1
-export NCCL_CHECKS_DISABLE=1
-export NCCL_IB_HCA=rdma0,rdma1,rdma2,rdma3,rdma4,rdma5,rdma6,rdma7 
-export NCCL_IB_GID_INDEX=3
-export NCCL_CROSS_NIC=0
-export CUDA_DEVICE_MAX_CONNECTIONS=1
-export NCCL_PROTO=Simple
-export RCCL_MSCCL_ENABLE=0
-export TOKENIZERS_PARALLELISM=false
-export HSA_NO_SCRATCH_RECLAIM=1
+export GPU_MAX_HW_QUEUES=${GPU_MAX_HW_QUEUES:-2}
+export TORCH_NCCL_HIGH_PRIORITY=${TORCH_NCCL_HIGH_PRIORITY:-1}
+export NCCL_CHECKS_DISABLE=${NCCL_CHECKS_DISABLE:-1}
+NCCL_IB_HCA_LIST=$(rdma link -j 2>/dev/null | python3 -c "import json, sys
+try:
+    links = json.load(sys.stdin)
+    print(*[links[i][\"ifname\"] for i in range(min(8, len(links)))], sep=',')
+except Exception:
+    pass") || NCCL_IB_HCA_LIST=""
+export NCCL_IB_HCA=${NCCL_IB_HCA:-$NCCL_IB_HCA_LIST}
+export NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX:-3}
+export NCCL_CROSS_NIC=${NCCL_CROSS_NIC:-0}
+export CUDA_DEVICE_MAX_CONNECTIONS=${CUDA_DEVICE_MAX_CONNECTIONS:-1}
+export NCCL_PROTO=${NCCL_PROTO:-Simple}
+export RCCL_MSCCL_ENABLE=${RCCL_MSCCL_ENABLE:-0}
+export TOKENIZERS_PARALLELISM=${TOKENIZERS_PARALLELISM:-false}
+export HSA_NO_SCRATCH_RECLAIM=${HSA_NO_SCRATCH_RECLAIM:-1}
 
 
 # parsing input arguments


### PR DESCRIPTION
### Problem

`examples/qwen/train_qwen2.sh` (line 13 before this PR) unconditionally exports a hardcoded NCCL InfiniBand device list:

```bash
export NCCL_IB_HCA=rdma0,rdma1,rdma2,rdma3,rdma4,rdma5,rdma6,rdma7
```

Two issues:

1. **No env-var override.** Using plain `export` (instead of the `${VAR:-default}` form) silently overrides any value the caller exported before invoking the script. Multinode launchers that try to pass a correct device list are ignored.
2. **Wrong defaults for any cluster whose RDMA NICs are not named `rdma*`.** On Broadcom NICs the kernel exposes `bnxt_re0..bnxt_re7`; Mellanox cards present as `mlx5_0..mlx5_N`. NCCL fails to find any of `rdma0..rdma7`, finds no IB-verbs device, and silently falls back to TCP-over-Ethernet. The fallback is masked by `NCCL_CHECKS_DISABLE=1` on the line above, so users see no warning — only collapsed multinode throughput.

### Impact

Multinode Qwen2 training on any AMD/ROCm cluster whose RDMA NICs aren't named `rdma*` runs over TCP rather than RDMA, with tokens/GPU/s dropping accordingly. Observed in our own multinode benchmarking on an AMD MI355X cluster with Broadcom `bnxt_re*` NICs: single-node was fine, 2-node was a fraction of expected; `NCCL_DEBUG=INFO` (with `NCCL_CHECKS_DISABLE` unset) confirmed the silent TCP fallback.

### Fix

Adopt the same auto-discovery + override pattern that this repo already uses in [`examples/mixtral/train_mixtral_moe.sh`](https://github.com/ROCm/Megatron-LM/blob/rocm_dev/examples/mixtral/train_mixtral_moe.sh) and [`examples/deepseek_v2/train_deepseekv2.sh`](https://github.com/ROCm/Megatron-LM/blob/rocm_dev/examples/deepseek_v2/train_deepseekv2.sh):

```bash
NCCL_IB_HCA_LIST=$(rdma link -j 2>/dev/null | python3 -c "import json, sys
try:
    links = json.load(sys.stdin)
    print(*[links[i][\"ifname\"] for i in range(min(8, len(links)))], sep=',')
except Exception:
    pass") || NCCL_IB_HCA_LIST=""
export NCCL_IB_HCA=${NCCL_IB_HCA:-$NCCL_IB_HCA_LIST}
```

And convert the surrounding plain `export VAR=value` lines to `export VAR=${VAR:-value}` so the rest of the block is also caller-overridable. The new block is byte-identical to the one in `examples/mixtral/train_mixtral_moe.sh`.

### Scope

- **Single file**: `examples/qwen/train_qwen2.sh` only.
- **No behavior change on existing `rdma*` clusters**: `rdma link -j` returns `rdma0..rdma7` there, so the default is unchanged. Explicit `NCCL_IB_HCA` overrides are now respected (previously silently overwritten).
- No fix audit beyond Qwen — Mixtral and DeepSeek-V2 already use this pattern.

### Validation

Pattern-parity with the working Mixtral / DeepSeek-V2 scripts in the same repo. `bash -n examples/qwen/train_qwen2.sh` passes. Happy to add cluster benchmark numbers on request.
