### PR TITLE
Add --use-te-activation-func option to training scripts

### DIFF
--- a/examples/deepseek_v2/train_deepseekv2.sh
+++ b/examples/deepseek_v2/train_deepseekv2.sh
@@ -389,6 +389,7 @@ megatron_options="  \
         --legacy-tokenizer \
         --dataset LLama-Pretrain-Idxmap \
         --swiglu \
+        --use-te-activation-func \
         --normalization RMSNorm \
         --norm-epsilon 1e-06 \
         --use-rotary-position-embeddings \

--- a/examples/deepseek_v3/train_deepseekv3.sh
+++ b/examples/deepseek_v3/train_deepseekv3.sh
@@ -529,6 +529,7 @@ megatron_options="  \
         --legacy-tokenizer
         --dataset LLama-Pretrain-Idxmap \
         --swiglu \
+        --use-te-activation-func \
         --normalization RMSNorm \
         --norm-epsilon 1e-06 \
         --use-rotary-position-embeddings \

--- a/examples/llama/train_llama2.sh
+++ b/examples/llama/train_llama2.sh
@@ -192,6 +192,7 @@ GPT_ARGS="
     --position-embedding-type rope \
     --no-position-embedding \
     --swiglu \
+    --use-te-activation-func \
     --disable-bias-linear \
     --init-method-std 0.02 \
     --attention-dropout 0.0 \

--- a/examples/llama/train_llama3.sh
+++ b/examples/llama/train_llama3.sh
@@ -173,6 +173,7 @@ GPT_ARGS="
     --position-embedding-type rope \
     --no-position-embedding \
     --swiglu \
+    --use-te-activation-func \
     --disable-bias-linear \
     --init-method-std 0.02 \
     --attention-dropout 0.0 \

--- a/examples/mixtral/train_mixtral_moe.sh
+++ b/examples/mixtral/train_mixtral_moe.sh
@@ -291,6 +291,7 @@ MODEL_ARGS=(
     --normalization RMSNorm
     --position-embedding-type rope
     --swiglu
+    --use-te-activation-func
     --untie-embeddings-and-output-weights
     --group-query-attention
     --num-query-groups 8
@@ -314,6 +315,7 @@ MODEL_ARGS=(
     --normalization RMSNorm
     --position-embedding-type rope
     --swiglu
+    --use-te-activation-func
     --untie-embeddings-and-output-weights
     --group-query-attention
     --num-query-groups 8

--- a/examples/qwen/train_qwen2.sh
+++ b/examples/qwen/train_qwen2.sh
@@ -163,6 +163,7 @@ GPT_ARGS="
     --no-position-embedding \
     --disable-bias-linear \
     --swiglu \
+    --use-te-activation-func \
     --init-method-std 0.02 \
     --attention-dropout 0.0 \
     --hidden-dropout 0.0 \


### PR DESCRIPTION
# What does this PR do ?
Add --use-te-activation-func to use TE kernels for activation across training scripts