### PR TITLE
Add --no-bias-swiglu-fusion option to training scripts HOTFIX

### DIFF
--- a/examples/deepseek_v3/train_deepseekv3.sh
+++ b/examples/deepseek_v3/train_deepseekv3.sh
@@ -530,6 +530,7 @@ megatron_options="  \
         --dataset LLama-Pretrain-Idxmap \
         --swiglu \
         --use-te-activation-func \
+        --no-bias-swiglu-fusion \
         --normalization RMSNorm \
         --norm-epsilon 1e-06 \
         --use-rotary-position-embeddings \

--- a/examples/llama/train_llama2.sh
+++ b/examples/llama/train_llama2.sh
@@ -193,6 +193,7 @@ GPT_ARGS="
     --no-position-embedding \
     --swiglu \
     --use-te-activation-func \
+    --no-bias-swiglu-fusion \
     --disable-bias-linear \
     --init-method-std 0.02 \
     --attention-dropout 0.0 \

--- a/examples/llama/train_llama3.sh
+++ b/examples/llama/train_llama3.sh
@@ -174,6 +174,7 @@ GPT_ARGS="
     --no-position-embedding \
     --swiglu \
     --use-te-activation-func \
+    --no-bias-swiglu-fusion \
     --disable-bias-linear \
     --init-method-std 0.02 \
     --attention-dropout 0.0 \

--- a/examples/mixtral/train_mixtral_moe.sh
+++ b/examples/mixtral/train_mixtral_moe.sh
@@ -292,6 +292,7 @@ MODEL_ARGS=(
     --position-embedding-type rope
     --swiglu
     --use-te-activation-func
+    --no-bias-swiglu-fusion
     --untie-embeddings-and-output-weights
     --group-query-attention
     --num-query-groups 8
@@ -316,6 +317,7 @@ MODEL_ARGS=(
     --position-embedding-type rope
     --swiglu
     --use-te-activation-func
+    --no-bias-swiglu-fusion
     --untie-embeddings-and-output-weights
     --group-query-attention
     --num-query-groups 8

--- a/examples/qwen/train_qwen2.sh
+++ b/examples/qwen/train_qwen2.sh
@@ -170,6 +170,7 @@ GPT_ARGS="
     --disable-bias-linear \
     --swiglu \
     --use-te-activation-func \
+    --no-bias-swiglu-fusion \
     --init-method-std 0.02 \
     --attention-dropout 0.0 \
     --hidden-dropout 0.0 \


### PR DESCRIPTION
## What does this PR do?
bias_activation_fusion and use_te_activation_func cannot be both true.  The recommendation is If you use bias in MLP FC1, set bias_activation_fusion to True and use_te_activation_func to False. Since all the training scripts has --disable-bias-linear, it disables bias in MLP layers, hence it's safe to add -no-bias-swiglu-fusion when using --use-te-activation-func.