### PR TITLE
MXFP4 recipe enablement

### DIFF
--- a/examples/llama/train_llama3.sh
+++ b/examples/llama/train_llama3.sh
@@ -71,6 +71,12 @@ SEQ_PARALLEL="${SEQ_PARALLEL:-1}"
 CONTI_PARAMS="${CONTI_PARAMS:-0}"
 TE_FP8="${TE_FP8:-0}"  # 0: disable FP8, 1: enable FP8
 TE_FP8_RECIPE="${TE_FP8_RECIPE:-delayed}" # Options: delayed, tensorwise, mxfp8
+TE_FP4="${TE_FP4:-0}"  # 0: disable FP4, 1: enable FP4
+TE_FP4_RECIPE="${TE_FP4_RECIPE:-nvfp4}" # Options: nvfp4, mxfp4
+FP4_PARAM_GATHER="${FP4_PARAM_GATHER:-0}"
+FP4_SELECTIVE_BF16="${FP4_SELECTIVE_BF16:-1}"  # 1: keep first/last layers in BF16 (NVFP4 paper recipe)
+FP4_BF16_START="${FP4_BF16_START:-2}"    # Number of layers at start in BF16 (paper: 2)
+FP4_BF16_END="${FP4_BF16_END:-8}"        # Number of layers at end in BF16 (paper: 8)
 GEMM_TUNING="${GEMM_TUNING:-1}"
 MCORE="${MCORE:-1}"
 OPTIMIZER="${OPTIMIZER:-adam}"
@@ -90,6 +96,11 @@ FP8_PARAM_GATHER="${FP8_PARAM_GATHER:-0}"
 FP8_TRANSPOSE_CACHE="${FP8_TRANSPOSE_CACHE:-0}"
 ENABLE_HSDP="${ENABLE_HSDP:-0}"
 HSDP_NUM_REPLICAS="${HSDP_NUM_REPLICAS:-2}"
+
+if [ "$TE_FP8" -eq 1 ] && [ "$TE_FP4" -eq 1 ]; then
+    echo "Error: FP8 and FP4 cannot be used simultaneously. Please choose one."
+    exit 1
+fi
 
 if [ "$FSDP" -eq 1 ] || [ "$MEGATRON_FSDP" -eq 1 ]; then
     unset CUDA_DEVICE_MAX_CONNECTIONS
@@ -350,6 +361,32 @@ if [ "$TE_FP8" -eq 1 ]; then
         EXTRA_ARGS="$EXTRA_ARGS --keep-fp8-weight-transpose-cache-te \
             --keep-fp8-transpose-cache \
         " 
+    fi
+fi
+
+if [ "$TE_FP4" -eq 1 ]; then
+    EXTRA_ARGS="$EXTRA_ARGS --transformer-impl=transformer_engine \
+        --fp4-format=e2m1 \
+    "
+
+    if [ "$TE_FP4_RECIPE" == "nvfp4" ]; then
+        EXTRA_ARGS="$EXTRA_ARGS --fp4-recipe=nvfp4"
+    elif [ "$TE_FP4_RECIPE" == "mxfp4" ]; then
+        EXTRA_ARGS="$EXTRA_ARGS --fp4-recipe=mxfp4"
+    else
+        echo "$TE_FP4_RECIPE is not supported"
+        exit 1
+    fi
+
+    if [ "$FP4_SELECTIVE_BF16" -eq 1 ]; then
+        EXTRA_ARGS="$EXTRA_ARGS --first-last-layers-bf16 \
+            --num-layers-at-start-in-bf16 $FP4_BF16_START \
+            --num-layers-at-end-in-bf16 $FP4_BF16_END \
+        "
+        echo "FP4 ($TE_FP4_RECIPE): Keeping first $FP4_BF16_START and last $FP4_BF16_END layers in BF16"
+    fi
+    if [ "$FP4_PARAM_GATHER" -eq 1 ]; then
+        EXTRA_ARGS="$EXTRA_ARGS --fp4-param-gather"
     fi
 fi
 

--- a/gpt_builders.py
+++ b/gpt_builders.py
@@ -136,6 +136,7 @@ def _get_transformer_layer_spec(use_te, config):
             moe_use_legacy_grouped_gemm=args.moe_use_legacy_grouped_gemm,
             qk_l2_norm=args.qk_l2_norm,
             use_kitchen=config.use_kitchen,
+            use_te_activation_func=config.use_te_activation_func,
             use_kitchen_attention=config.use_kitchen_attention,
             kitchen_attention_backend=config.kitchen_attention_backend,
         )

--- a/megatron/core/enums.py
+++ b/megatron/core/enums.py
@@ -31,4 +31,5 @@ class Fp4Recipe(str, enum.Enum):
     """FP4 recipe names: nvfp4, custom."""
 
     nvfp4 = "nvfp4"
+    mxfp4 = "mxfp4"
     custom = "custom"

--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -249,6 +249,8 @@ def _get_fp8_autocast_for_quant_recipe(qrecipe: TEQuantizationRecipe):
             # Fp4 configured.
             if qrecipe.fp4_quantization_recipe == Fp4Recipe.nvfp4:
                 quant_recipe = te.common.recipe.NVFP4BlockScaling()
+            elif qrecipe.fp4_quantization_recipe == Fp4Recipe.mxfp4:
+                quant_recipe = te.common.recipe.MXFP4BlockScaling()
             else:
                 raise ValueError(f"Unhandled fp4 recipe: {qrecipe.fp8_quantization_recipe}")
 

--- a/megatron/core/fp4_utils.py
+++ b/megatron/core/fp4_utils.py
@@ -42,7 +42,7 @@ else:
     HAVE_TE_FP4_TENSOR_CLASS = False
     FP4_TENSOR_CLASS = None
 
-# MXFP4Tensor is available from Transformer Engine 2.12.0.dev0 onward.
+# MXFP4Tensor is available from Transformer Engine ROCm 2.12.0.dev0 onward.
 HAVE_TE_MXFP4_TENSOR_CLASS = False
 if HAVE_TE:
     if is_te_min_version("2.12.0.dev0"):

--- a/megatron/core/fp4_utils.py
+++ b/megatron/core/fp4_utils.py
@@ -42,10 +42,10 @@ else:
     HAVE_TE_FP4_TENSOR_CLASS = False
     FP4_TENSOR_CLASS = None
 
-# Check if Transformer Engine has class for fp4 tensors.
+# MXFP4Tensor is available from Transformer Engine 2.12.0.dev0 onward.
 HAVE_TE_MXFP4_TENSOR_CLASS = False
 if HAVE_TE:
-    if is_te_min_version("2.7.0.dev0"):
+    if is_te_min_version("2.12.0.dev0"):
         try:
             from transformer_engine.pytorch.tensor.mxfp4_tensor import (
                 MXFP4Tensor as MXFP4_TENSOR_CLASS,
@@ -132,13 +132,17 @@ if HAVE_TE:
                         >= 2.7.0.dev0."""
                     )
             elif config.fp4_recipe == Fp4Recipe.mxfp4:
+                if not is_te_min_version("2.12.0.dev0"):
+                    raise ValueError(
+                        "MXFP4BlockScaling requires Transformer Engine >= 2.12.0.dev0."
+                    )
                 try:
                     fp4_recipe = transformer_engine.common.recipe.MXFP4BlockScaling()
                 except AttributeError:
                     raise ValueError(
                         """MXFP4BlockScaling recipe is not available in this version of 
                         Transformer Engine. Please make sure you are using TE version 
-                        >= 2.7.0.dev0."""
+                        >= 2.12.0.dev0."""
                     )
             elif config.fp4_recipe == Fp4Recipe.custom:
                 fp4_recipe = _get_custom_recipe(config.fp4_quantizer_factory)

--- a/megatron/core/fp4_utils.py
+++ b/megatron/core/fp4_utils.py
@@ -42,11 +42,34 @@ else:
     HAVE_TE_FP4_TENSOR_CLASS = False
     FP4_TENSOR_CLASS = None
 
+# Check if Transformer Engine has class for fp4 tensors.
+HAVE_TE_MXFP4_TENSOR_CLASS = False
+if HAVE_TE:
+    if is_te_min_version("2.7.0.dev0"):
+        try:
+            from transformer_engine.pytorch.tensor.mxfp4_tensor import (
+                MXFP4Tensor as MXFP4_TENSOR_CLASS,
+            )
+
+            HAVE_TE_MXFP4_TENSOR_CLASS = True
+        except (ImportError, ModuleNotFoundError):
+            HAVE_TE_MXFP4_TENSOR_CLASS = False
+            MXFP4_TENSOR_CLASS = None
+    else:
+        HAVE_TE_MXFP4_TENSOR_CLASS = False
+        MXFP4_TENSOR_CLASS = None
+else:
+    HAVE_TE_MXFP4_TENSOR_CLASS = False
+    MXFP4_TENSOR_CLASS = None
+
 
 def is_nvfp4tensor(tensor: torch.Tensor) -> bool:
     """Check if a tensor is a Transformer Engine NVFP4Tensor."""
     return HAVE_TE_FP4_TENSOR_CLASS and isinstance(tensor, FP4_TENSOR_CLASS)
 
+def is_mxfp4tensor(tensor: torch.Tensor) -> bool:
+    """Check if a tensor is a Transformer Engine MXFP4Tensor."""
+    return HAVE_TE_MXFP4_TENSOR_CLASS and isinstance(tensor, MXFP4_TENSOR_CLASS)
 
 def get_fp4_align_size(fp4_recipe: Fp4Recipe) -> int:
     """
@@ -77,7 +100,12 @@ def get_fp4_align_size(fp4_recipe: Fp4Recipe) -> int:
     TE NVFP4 Grouped Quantization: https://github.com/NVIDIA/TransformerEngine/pull/2411
     """
     # pylint: disable=unused-argument
-    return 128
+    if fp4_recipe == Fp4Recipe.mxfp4:
+        return 256
+    elif fp4_recipe == Fp4Recipe.nvfp4:
+        return 128
+    else:
+        raise ValueError(f"Unsupported FP4 recipe: {fp4_recipe}")
 
 
 def dequantize_fp4_tensor(fp4_tensor: torch.Tensor) -> torch.Tensor:
@@ -103,17 +131,26 @@ if HAVE_TE:
                         Transformer Engine. Please make sure you are using TE version 
                         >= 2.7.0.dev0."""
                     )
+            elif config.fp4_recipe == Fp4Recipe.mxfp4:
+                try:
+                    fp4_recipe = transformer_engine.common.recipe.MXFP4BlockScaling()
+                except AttributeError:
+                    raise ValueError(
+                        """MXFP4BlockScaling recipe is not available in this version of 
+                        Transformer Engine. Please make sure you are using TE version 
+                        >= 2.7.0.dev0."""
+                    )
             elif config.fp4_recipe == Fp4Recipe.custom:
                 fp4_recipe = _get_custom_recipe(config.fp4_quantizer_factory)
             else:
                 raise ValueError(
-                    "NVFP4BlockScaling and custom are the only supported FP4 recipes. "
+                    "NVFP4BlockScaling, MXFP4BlockScaling and custom are the only supported FP4 recipes. "
                     "Please make sure you are using a compatible TE version >= 2.7.0.dev0."
                 )
         else:
             raise ValueError(
                 """FP4 support requires TransformerEngine version >= 2.7.0.dev0 
-                for NVFP4BlockScaling."""
+                for NVFP4BlockScaling and MXFP4BlockScaling."""
             )
         return fp4_recipe
 

--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -817,7 +817,7 @@ class _CudaGraphRunner(torch.nn.Module):
                 if is_te_min_version("2.7.0.dev0"):
                     saved_fp8_tensors = save_fp8_tensors([self.base_module], self.fp4_recipe)
                 else:
-                    raise ValueError("FP4 requires TE >= 2.7.0.dev0 for NVFP4BlockScaling support.")
+                    raise ValueError("FP4 requires TE >= 2.7.0.dev0 for NVFP4BlockScaling and MXFP4BlockScaling support.")
 
         # cache the moe aux loss if needed, which is accumulated inside the forward pass
         from megatron.core.transformer.transformer_layer import MoETransformerLayer
@@ -1217,10 +1217,10 @@ class _CudaGraphRunner(torch.nn.Module):
                 if FP8GlobalStateManager.is_fp8_enabled():
                     # check if the low precision recipe is either fp4 or fp8
                     if is_te_min_version("2.7.0.dev0"):
-                        from transformer_engine.common.recipe import NVFP4BlockScaling
+                        from transformer_engine.common.recipe import NVFP4BlockScaling, MXFP4BlockScaling
 
                         recipe = FP8GlobalStateManager.get_fp8_recipe()
-                        if isinstance(recipe, NVFP4BlockScaling):
+                        if isinstance(recipe, NVFP4BlockScaling) or isinstance(recipe, MXFP4BlockScaling):
                             self.fp4_runtime_enabled = True
                         else:
                             self.fp8_runtime_enabled = True

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -522,12 +522,11 @@ class TransformerConfig(ModelParallelConfig):
     fp4: Optional[Literal['e2m1']] = field(
         default=None, metadata={"argparse_meta": {"arg_names": ["--fp4-format"]}}
     )
-    """If set, enables the use of FP4 precision through Transformer Engine. Currently only 
-    supports 'nvfp4' which uses NVFP4BlockScaling recipe (requires TE >= 2.7.0.dev0)."""
+    """If set, enables the use of FP4 precision through Transformer Engine. Supports 'nvfp4' and 'mxfp4' which uses NVFP4BlockScaling and MXFP4BlockScaling recipe (requires TE >= 2.12.0.dev0)."""
 
-    fp4_recipe: Optional[Literal['nvfp4', 'custom']] = "nvfp4"
-    """If set, enables the use of FP4 precision through Transformer Engine. Currently only
-    'nvfp4' is supported which uses NVFP4BlockScaling recipe for Blackwell+ architecture."""
+    fp4_recipe: Optional[Literal['nvfp4', 'mxfp4', 'custom']] = "nvfp4"
+    """If set, enables the use of FP4 precision through Transformer Engine.
+    'nvfp4' and 'mxfp4' are supported which uses NVFP4BlockScaling and MXFP4BlockScaling recipe."""
 
     fp4_param: bool = field(
         default=False, metadata={"argparse_meta": {"arg_names": ["--fp4-param-gather"]}}

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -762,7 +762,7 @@ def validate_args(args, defaults={}):
 
     # FP4 requires TE >= 2.7.0.dev0
     if args.fp4 and not is_te_min_version("2.7.0.dev0"):
-        raise ValueError("--fp4-format requires Transformer Engine >= 2.7.0.dev0 for NVFP4BlockScaling support.")
+        raise ValueError("--fp4-format requires Transformer Engine >= 2.7.0.dev0 for NVFP4BlockScaling and MXFP4BlockScaling support.")
 
     if args.use_megatron_fsdp:
         # NOTE: The flag `use_custom_fsdp` is deprecated and will be removed in future versions.

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -760,9 +760,12 @@ def validate_args(args, defaults={}):
     if args.fp4_param and not args.fp4:
         raise ValueError("--fp4-param-gather must be used together with --fp4-format.")
 
-    # FP4 requires TE >= 2.7.0.dev0
+    # FP4 requires TE >= 2.7.0.dev0 (NVFP4)
     if args.fp4 and not is_te_min_version("2.7.0.dev0"):
-        raise ValueError("--fp4-format requires Transformer Engine >= 2.7.0.dev0 for NVFP4BlockScaling and MXFP4BlockScaling support.")
+        raise ValueError( "--fp4-format requires Transformer Engine >= 2.7.0.dev0 for NVFP4BlockScaling support.")
+
+    if args.fp4 and getattr(args, "fp4_recipe", "nvfp4") == "mxfp4" and not is_te_min_version("2.12.0.dev0"):
+        raise ValueError("--fp4-recipe=mxfp4 requires Transformer Engine >= 2.12.0.dev0 for MXFP4BlockScaling support.")
 
     if args.use_megatron_fsdp:
         # NOTE: The flag `use_custom_fsdp` is deprecated and will be removed in future versions.


### PR DESCRIPTION
# What does this PR do ?
Enables training with MXFP4 recipe in Megatron-LM.
Adds MXFP4 training options to llama3 example.