### PR TITLE
Enhance MoE unit test teardown process in conftest.py

### DIFF
--- a/tests/unit_tests/dist_checkpointing/test_safe_globals.py
+++ b/tests/unit_tests/dist_checkpointing/test_safe_globals.py
@@ -9,6 +9,7 @@ import pytest
 import torch
 
 from megatron.core.utils import is_torch_min_version
+from tests.unit_tests.test_utilities import Utils
 
 
 class UnsafeClass:
@@ -20,14 +21,19 @@ class UnsafeClass:
 
 
 class TestSafeGlobals:
+    def setup_method(self, method):
+        Utils.initialize_model_parallel(1, 1)
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
     def test_safe_globals(self, tmp_path_dist_ckpt):
         # create dummy checkpoint
         ckpt_path = tmp_path_dist_ckpt / "test_safe_globals.pt"
         dummy_obj = Namespace(dummy_value=0)
-        if not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0:
+        if Utils.rank == 0:
             torch.save(dummy_obj, ckpt_path)
-        if torch.distributed.is_initialized():
-            torch.distributed.barrier()
+        torch.distributed.barrier()
 
         torch.load(ckpt_path)
 
@@ -36,10 +42,9 @@ class TestSafeGlobals:
         # create dummy checkpoint
         ckpt_path = tmp_path_dist_ckpt / "test_unsafe_globals.pt"
         dummy_obj = UnsafeClass(123)
-        if not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0:
+        if Utils.rank == 0:
             torch.save(dummy_obj, ckpt_path)
-        if torch.distributed.is_initialized():
-            torch.distributed.barrier()
+        torch.distributed.barrier()
 
         # expected error
         with pytest.raises(UnpicklingError):

--- a/tests/unit_tests/pipeline_parallel/test_fine_grained_activation_offloading.py
+++ b/tests/unit_tests/pipeline_parallel/test_fine_grained_activation_offloading.py
@@ -152,6 +152,7 @@ def _run_one_iter_and_capture(
         (True, False, ["moe_act"]),
     ],
 )
+@pytest.mark.failing_on_rocm
 def test_gpt_fine_grained_activation_offloading_correctness_and_memory(
     is_moe: bool, is_mla: bool, offload_modules: List[str]
 ):
@@ -166,9 +167,7 @@ def test_gpt_fine_grained_activation_offloading_correctness_and_memory(
     os.environ.pop("NVTE_FLASH_ATTN", None)
     os.environ.pop("NVTE_UNFUSED_ATTN", None)
     # os.environ["NVTE_FLASH_ATTN"] = "1"
-    Utils.initialize_model_parallel(
-        tensor_model_parallel_size=1, pipeline_model_parallel_size=1, bind_pg_device=True
-    )
+    Utils.initialize_model_parallel(tensor_model_parallel_size=1, pipeline_model_parallel_size=1)
 
     seed = 123
     # Choose shapes large enough to make memory deltas stable but still fast.

--- a/tests/unit_tests/pipeline_parallel/test_fine_grained_activation_offloading.py
+++ b/tests/unit_tests/pipeline_parallel/test_fine_grained_activation_offloading.py
@@ -166,7 +166,9 @@ def test_gpt_fine_grained_activation_offloading_correctness_and_memory(
     os.environ.pop("NVTE_FLASH_ATTN", None)
     os.environ.pop("NVTE_UNFUSED_ATTN", None)
     # os.environ["NVTE_FLASH_ATTN"] = "1"
-    Utils.initialize_model_parallel(tensor_model_parallel_size=1, pipeline_model_parallel_size=1)
+    Utils.initialize_model_parallel(
+        tensor_model_parallel_size=1, pipeline_model_parallel_size=1, bind_pg_device=True
+    )
 
     seed = 123
     # Choose shapes large enough to make memory deltas stable but still fast.

--- a/tests/unit_tests/test_utilities.py
+++ b/tests/unit_tests/test_utilities.py
@@ -34,7 +34,7 @@ class Utils:
     store = None
 
     @staticmethod
-    def initialize_distributed(bind_pg_device=False):
+    def initialize_distributed():
 
         os.environ.pop('NVTE_FLASH_ATTN', None)
         os.environ.pop('NVTE_FUSED_ATTN', None)
@@ -61,24 +61,8 @@ class Utils:
             store = PrefixStore("default_pg", store)
             Utils.store = store
 
-            # Optionally bind the PG to this rank's device. Without an explicit
-            # device_id the process group never gets a definitive device, so object
-            # collectives pick a device ambiguously, which
-            # RCCL/NCCL warns "can potentially cause a hang". This is the source of
-            # the intermittent deadlock seen only under longer/heavier test suites.
-            # Off by default so behavior is unchanged for the whole suite; tests
-            # that need it pass bind_pg_device=True.
-            init_pg_kwargs = {}
-            if bind_pg_device:
-                init_pg_kwargs['device_id'] = torch.device(
-                    'cuda', Utils.rank % torch.cuda.device_count()
-                )
             torch.distributed.init_process_group(
-                backend='nccl',
-                world_size=Utils.world_size,
-                rank=Utils.rank,
-                store=store,
-                **init_pg_kwargs,
+                backend='nccl', world_size=Utils.world_size, rank=Utils.rank, store=store
             )
 
             torch.distributed.barrier()
@@ -116,7 +100,6 @@ class Utils:
         tensor_model_parallel_size=1,
         pipeline_model_parallel_size=1,
         virtual_pipeline_model_parallel_size=None,
-        bind_pg_device=False,
         **kwargs,
     ):
         # Need to unset these variables to make sure previous
@@ -126,7 +109,7 @@ class Utils:
         os.environ.pop('NVTE_UNFUSED_ATTN', None)
 
         ps.destroy_model_parallel()
-        Utils.initialize_distributed(bind_pg_device=bind_pg_device)
+        Utils.initialize_distributed()
         ps.initialize_model_parallel(
             tensor_model_parallel_size,
             pipeline_model_parallel_size,

--- a/tests/unit_tests/test_utilities.py
+++ b/tests/unit_tests/test_utilities.py
@@ -34,7 +34,7 @@ class Utils:
     store = None
 
     @staticmethod
-    def initialize_distributed():
+    def initialize_distributed(bind_pg_device=False):
 
         os.environ.pop('NVTE_FLASH_ATTN', None)
         os.environ.pop('NVTE_FUSED_ATTN', None)
@@ -61,18 +61,24 @@ class Utils:
             store = PrefixStore("default_pg", store)
             Utils.store = store
 
-            # Bind the PG to this rank's device. Without an explicit device_id the
-            # process group never gets a definitive device, so object collectives
-            # (e.g. all_gather_object) pick a device ambiguously, which RCCL/NCCL
-            # warns "can potentially cause a hang". This is the source of the
-            # intermittent deadlock seen only under longer/heavier test suites.
-            device_id = torch.device('cuda', Utils.rank % torch.cuda.device_count())
+            # Optionally bind the PG to this rank's device. Without an explicit
+            # device_id the process group never gets a definitive device, so object
+            # collectives pick a device ambiguously, which
+            # RCCL/NCCL warns "can potentially cause a hang". This is the source of
+            # the intermittent deadlock seen only under longer/heavier test suites.
+            # Off by default so behavior is unchanged for the whole suite; tests
+            # that need it pass bind_pg_device=True.
+            init_pg_kwargs = {}
+            if bind_pg_device:
+                init_pg_kwargs['device_id'] = torch.device(
+                    'cuda', Utils.rank % torch.cuda.device_count()
+                )
             torch.distributed.init_process_group(
                 backend='nccl',
                 world_size=Utils.world_size,
                 rank=Utils.rank,
                 store=store,
-                device_id=device_id,
+                **init_pg_kwargs,
             )
 
             torch.distributed.barrier()
@@ -110,6 +116,7 @@ class Utils:
         tensor_model_parallel_size=1,
         pipeline_model_parallel_size=1,
         virtual_pipeline_model_parallel_size=None,
+        bind_pg_device=False,
         **kwargs,
     ):
         # Need to unset these variables to make sure previous
@@ -119,7 +126,7 @@ class Utils:
         os.environ.pop('NVTE_UNFUSED_ATTN', None)
 
         ps.destroy_model_parallel()
-        Utils.initialize_distributed()
+        Utils.initialize_distributed(bind_pg_device=bind_pg_device)
         ps.initialize_model_parallel(
             tensor_model_parallel_size,
             pipeline_model_parallel_size,

--- a/tests/unit_tests/test_utilities.py
+++ b/tests/unit_tests/test_utilities.py
@@ -61,8 +61,18 @@ class Utils:
             store = PrefixStore("default_pg", store)
             Utils.store = store
 
+            # Bind the PG to this rank's device. Without an explicit device_id the
+            # process group never gets a definitive device, so object collectives
+            # (e.g. all_gather_object) pick a device ambiguously, which RCCL/NCCL
+            # warns "can potentially cause a hang". This is the source of the
+            # intermittent deadlock seen only under longer/heavier test suites.
+            device_id = torch.device('cuda', Utils.rank % torch.cuda.device_count())
             torch.distributed.init_process_group(
-                backend='nccl', world_size=Utils.world_size, rank=Utils.rank, store=store
+                backend='nccl',
+                world_size=Utils.world_size,
+                rank=Utils.rank,
+                store=store,
+                device_id=device_id,
             )
 
             torch.distributed.barrier()

--- a/tests/unit_tests/transformer/moe/conftest.py
+++ b/tests/unit_tests/transformer/moe/conftest.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
 # Modified for portability across upstream and ROCm CI environments.
 
+import logging
 import os
 from pathlib import Path
 
@@ -33,8 +34,8 @@ def _destroy_tracked_process_groups():
             continue
         try:
             torch.distributed.destroy_process_group(group)
-        except Exception:
-            pass
+        except Exception as e:
+            logging.getLogger(__name__).debug("Failed to destroy %s: %s", group, e)
 
     parallel_state._global_process_group_list = None
 
@@ -57,12 +58,18 @@ def _destroy_model_parallel_with_subgroups():
 
 
 @pytest.fixture(autouse=True)
-def moe_model_parallel_teardown():
+def moe_model_parallel_teardown(monkeypatch):
     """Ensure MoE unit tests destroy tracked subgroups between topology changes."""
-    original_destroy = Utils.destroy_model_parallel
-    Utils.destroy_model_parallel = staticmethod(_destroy_model_parallel_with_subgroups)
+    monkeypatch.setattr(
+        Utils,
+        "destroy_model_parallel",
+        staticmethod(_destroy_model_parallel_with_subgroups),
+    )
     yield
-    Utils.destroy_model_parallel = original_destroy
+    # Safety net: a test that errors before its own teardown would otherwise
+    # leak NCCL/RCCL subgroups into the next test.
+    if Utils.inited:
+        _destroy_model_parallel_with_subgroups()
 
 
 def pytest_sessionfinish(session, exitstatus):

--- a/tests/unit_tests/transformer/moe/conftest.py
+++ b/tests/unit_tests/transformer/moe/conftest.py
@@ -1,4 +1,7 @@
 # Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Modified for portability across upstream and ROCm CI environments.
+
 import os
 from pathlib import Path
 
@@ -6,23 +9,65 @@ import pytest
 import torch
 import torch.distributed
 
+import megatron.core.parallel_state as parallel_state
 from megatron.core.utils import is_te_min_version
 from tests.unit_tests.dist_checkpointing import TempNamedDir
 from tests.unit_tests.test_utilities import Utils
 
 
+def _destroy_tracked_process_groups():
+    """Destroy non-default process groups left after model-parallel init."""
+    if not torch.distributed.is_initialized():
+        return
+
+    group_list = parallel_state._global_process_group_list
+    if group_list is None:
+        return
+
+    default_pg = torch.distributed.group.WORLD
+    pg_map = torch.distributed.distributed_c10d._world.pg_map
+    for group in reversed(group_list):
+        if group is None or group == default_pg:
+            continue
+        if pg_map.get(group, None) is None:
+            continue
+        try:
+            torch.distributed.destroy_process_group(group)
+        except Exception:
+            pass
+
+    parallel_state._global_process_group_list = None
+
+
+def _destroy_model_parallel_with_subgroups():
+    """Teardown model parallel state and destroy tracked NCCL subgroups."""
+    os.environ.pop('NVTE_FLASH_ATTN', None)
+    os.environ.pop('NVTE_FUSED_ATTN', None)
+    os.environ.pop('NVTE_UNFUSED_ATTN', None)
+    if not Utils.inited:
+        return
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+    torch.distributed.barrier()
+    _destroy_tracked_process_groups()
+    parallel_state.destroy_model_parallel()
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+    Utils.inited = False
+
+
+@pytest.fixture(autouse=True)
+def moe_model_parallel_teardown():
+    """Ensure MoE unit tests destroy tracked subgroups between topology changes."""
+    original_destroy = Utils.destroy_model_parallel
+    Utils.destroy_model_parallel = staticmethod(_destroy_model_parallel_with_subgroups)
+    yield
+    Utils.destroy_model_parallel = original_destroy
+
+
 def pytest_sessionfinish(session, exitstatus):
     if exitstatus == 5:
         session.exitstatus = 0
-
-
-@pytest.fixture(scope="session", autouse=True)
-def cleanup():
-    yield
-    if torch.distributed.is_initialized():
-        print("Waiting for destroy_process_group")
-        torch.distributed.barrier()
-        torch.distributed.destroy_process_group()
 
 
 @pytest.fixture(scope="function", autouse=True)


### PR DESCRIPTION
- Added functions to destroy non-default process groups and model parallel state to ensure proper cleanup between tests.
- Introduced a new fixture, `moe_model_parallel_teardown`, to automatically handle the teardown of tracked NCC/RCCL subgroups during unit tests.