### PR TITLE
examples/llama: fix FSDP grad-accum-fusion regression + propagate train exit status

### DIFF
--- a/examples/llama/train_llama2.sh
+++ b/examples/llama/train_llama2.sh
@@ -473,8 +473,18 @@ else
     run_cmd="$run_cmd |& tee $TRAIN_LOG"
 fi
 
-if [ "$NO_TRAINING" -eq 0 ]; then 
+TRAIN_RC=0
+if [ "$NO_TRAINING" -eq 0 ]; then
+    # pipefail so the run's `... |& tee $TRAIN_LOG` (TEE_OUTPUT=1) returns torchrun's status, not tee's
+    # (~always 0). Without it a training crash is masked and the script would exit 0. ($? after `eval`
+    # of the pipeline, since `eval` collapses PIPESTATUS to a single element = tee's status.)
+    set -o pipefail
     eval $run_cmd
+    TRAIN_RC=$?
+    set +o pipefail
+    if [ "$TRAIN_RC" -ne 0 ]; then
+        echo "ERROR: training (torchrun pretrain_gpt.py) failed with exit code $TRAIN_RC" |& tee -a $TRAIN_LOG
+    fi
 fi
 
 
@@ -515,4 +525,7 @@ grep -Eo 'mem usages: [^|]*' "$TRAIN_LOG" | sed -E 's/.*mem usages: ([0-9\.]+).*
 MEMUSAGE=$(python3 mean_log_value.py tmp.txt)
 echo "mem usages: $MEMUSAGE" |& tee -a "$TRAIN_LOG"
 rm tmp.txt
+
+# Propagate the training exit status (the perf-parse above must not mask a torchrun failure).
+exit $TRAIN_RC
 

--- a/examples/llama/train_llama2.sh
+++ b/examples/llama/train_llama2.sh
@@ -123,6 +123,13 @@ fi
 
 if [ "$FSDP" -eq 1 ] || [ "$MEGATRON_FSDP" -eq 1 ]; then
     unset CUDA_DEVICE_MAX_CONNECTIONS
+    # Gradient accumulation fusion is incompatible with FSDP: torch-FSDP2 hard-asserts against it
+    # in arguments.py, and Megatron-FSDP crashes at runtime with an fsdp_grads "No buffer found for
+    # bucket_id" assertion. Force it off so the default-on toggle does not break the FSDP suites.
+    if [ "$GRADIENT_ACCUMULATION_FUSION" -eq 1 ]; then
+        echo "FSDP is incompatible with gradient accumulation fusion; disabling fusion (GRADIENT_ACCUMULATION_FUSION=0)."
+        GRADIENT_ACCUMULATION_FUSION=0
+    fi
     if [ "$TP" -gt 1 ]; then
         echo "It is not recommended to use FSDP and TP together. Disabling TP."
         TP=1

--- a/examples/llama/train_llama3.sh
+++ b/examples/llama/train_llama3.sh
@@ -137,6 +137,13 @@ fi
 
 if [ "$FSDP" -eq 1 ] || [ "$MEGATRON_FSDP" -eq 1 ]; then
     unset CUDA_DEVICE_MAX_CONNECTIONS
+    # Gradient accumulation fusion is incompatible with FSDP: torch-FSDP2 hard-asserts against it
+    # in arguments.py, and Megatron-FSDP crashes at runtime with an fsdp_grads "No buffer found for
+    # bucket_id" assertion. Force it off so the default-on toggle does not break the FSDP suites.
+    if [ "$GRADIENT_ACCUMULATION_FUSION" -eq 1 ]; then
+        echo "FSDP is incompatible with gradient accumulation fusion; disabling fusion (GRADIENT_ACCUMULATION_FUSION=0)."
+        GRADIENT_ACCUMULATION_FUSION=0
+    fi
     if [ "$TP" -gt 1 ]; then
         echo "It is not recommended to use FSDP and TP together. Disabling TP."
         TP=1

--- a/examples/llama/train_llama3.sh
+++ b/examples/llama/train_llama3.sh
@@ -505,8 +505,18 @@ else
     run_cmd="$run_cmd |& tee $TRAIN_LOG"
 fi
 
-if [ "$NO_TRAINING" -eq 0 ]; then 
+TRAIN_RC=0
+if [ "$NO_TRAINING" -eq 0 ]; then
+    # pipefail so the run's `... |& tee $TRAIN_LOG` (TEE_OUTPUT=1) returns torchrun's status, not tee's
+    # (~always 0). Without it a training crash is masked and the script would exit 0. ($? after `eval`
+    # of the pipeline, since `eval` collapses PIPESTATUS to a single element = tee's status.)
+    set -o pipefail
     eval $run_cmd
+    TRAIN_RC=$?
+    set +o pipefail
+    if [ "$TRAIN_RC" -ne 0 ]; then
+        echo "ERROR: training (torchrun pretrain_gpt.py) failed with exit code $TRAIN_RC" |& tee -a $TRAIN_LOG
+    fi
 fi
 
 
@@ -547,3 +557,6 @@ grep -Eo 'mem usages: [^|]*' "$TRAIN_LOG" | sed -E 's/.*mem usages: ([0-9\.]+).*
 MEMUSAGE=$(python3 mean_log_value.py tmp.txt)
 echo "mem usages: $MEMUSAGE" |& tee -a "$TRAIN_LOG"
 rm tmp.txt
+
+# Propagate the training exit status (the perf-parse above must not mask a torchrun failure).
+exit $TRAIN_RC


### PR DESCRIPTION
## Summary

Two independent fixes to `examples/llama/train_llama{2,3}.sh`:

1. **Disable gradient accumulation fusion on FSDP paths.** The perf toggle added in #141 defaults `GRADIENT_ACCUMULATION_FUSION` **on**, but fusion is incompatible with both FSDP backends, so every FSDP run (the test harness drives `--fsdp 1`) broke:
   - **torch-FSDP2** (`FSDP=1` ~F~R `--use-torch-fsdp2`) hard-asserts in `arguments.py`: `--use-torch-fsdp2 is not suu
pported with gradient accumulation fusion`.
   - **Megatron-FSDP** (`MEGATRON_FSDP=1`) crashes at runtime: `[FSDP][Rank N][fsdp_grads] No buffer found for bucket_id ...`.

   Fix: force `GRADIENT_ACCUMULATION_FUSION=0` inside the existing `FSDP || MEGATRON_FSDP` block (with a notice). The non-FSDP path keeps fusion on.

2. **Propagate the training exit status.** The scripts exited `0` even when `torchrun` crashed, so CI gating on exit code saw failures as passes ~@~T which is how the #141 regression slipped through green. Two masks: `eval $run_cmd` stt
atus was discarded (and with `TEE_OUTPUT=1` the `... |& tee` pipeline returns `tee`'s status, ~0), and the trailing perf-parse became the script's exit code. Fix: `set -o pipefail` + capture `$?`, emit an explicit error line, and `exit $TRAIN_RC` at the end.

## Verification (8~WMI355X, MODEL_SIZE=8, mock data, 3 iters)

| Config | Before | After |
|---|---|---|
| FSDP2 + fusion on | assert | trains (fusion auto-off) |
| Megatron-FSDP + fusion on | grad-bucket crash | trains (fusion auto-off) |
| no-FSDP + fusion on | ok | fusion stays on |
| forced torchrun failure | exit 0 (masked) | exit != 0 (TEE_OUTPUT 0 and 1) |
| clean run | exit 0 | exit 0 |

Immediate unblock without the script change: run with `GRADIENT_ACCUMULATION_FUSION=0`.