### PR TITLE
fix: add per-test-file timeout to prevent CI from hanging 12h

### DIFF
--- a/run_unit_tests.sh
+++ b/run_unit_tests.sh
@@ -21,7 +21,9 @@ fi
 
 # Per-test-file timeout in seconds (30 minutes).
 # Prevents a single hung torchrun from consuming the entire CI time budget.
+# --kill-after=300: if SIGTERM is ignored, SIGKILL after 5 more minutes.
 TEST_TIMEOUT=${TEST_TIMEOUT:-1800}
+KILL_AFTER=${KILL_AFTER:-300}
 
 # Find all test files recursively
 TEST_FILES=$(find tests/unit_tests -type f -name "test_*.py")
@@ -37,7 +39,7 @@ for file in $TEST_FILES; do
     xml_file="$OUT_DIR/junit_report_${test_name}.xml"
 
     echo "Running test file: $file"
-    timeout "$TEST_TIMEOUT" \
+    timeout --kill-after="$KILL_AFTER" "$TEST_TIMEOUT" \
         torchrun --standalone --nproc_per_node=$NUM_GPUS -m pytest \
             --showlocals --tb=long -v -s -m "$PYTEST_MARKERS" \
             --csv "$csv_file" \
@@ -45,8 +47,9 @@ for file in $TEST_FILES; do
             $file
     rc=$?
 
-    if [[ $rc -eq 124 ]]; then
-        echo "TIMEOUT: $file exceeded ${TEST_TIMEOUT}s — marking as failed."
+    # exit code 124 = SIGTERM timeout; 137 = SIGKILL (--kill-after triggered)
+    if [[ $rc -eq 124 ]] || [[ $rc -eq 137 ]]; then
+        echo "TIMEOUT: $file exceeded ${TEST_TIMEOUT}s (kill-after=${KILL_AFTER}s) — marking as failed."
         ANY_FAIL=1
     elif [[ $rc -ne 0 ]]; then
         echo "Test failed in $file."

--- a/run_unit_tests.sh
+++ b/run_unit_tests.sh
@@ -19,6 +19,10 @@ if [[ "$HIP_ARCHITECTURES" == "gfx90a" ]]; then
     PYTEST_MARKERS="$PYTEST_MARKERS and not failing_on_rocm_mi250"
 fi
 
+# Per-test-file timeout in seconds (30 minutes).
+# Prevents a single hung torchrun from consuming the entire CI time budget.
+TEST_TIMEOUT=${TEST_TIMEOUT:-1800}
+
 # Find all test files recursively
 TEST_FILES=$(find tests/unit_tests -type f -name "test_*.py")
 
@@ -28,19 +32,23 @@ for file in $TEST_FILES; do
     # Create unique filename by replacing slashes with underscores and removing tests/unit_tests/ prefix
     # E.g., tests/unit_tests/dist_checkpointing/test_optimizer.py -> dist_checkpointing_test_optimizer
     test_name=$(echo "$file" | sed 's|tests/unit_tests/||' | sed 's|/|_|g' | sed 's|\.py$||')
-    
+
     csv_file="$OUT_DIR/test_report_${test_name}.csv"
     xml_file="$OUT_DIR/junit_report_${test_name}.xml"
 
     echo "Running test file: $file"
-    torchrun --standalone --nproc_per_node=$NUM_GPUS -m pytest \
-        --showlocals --tb=long -v -s -m "$PYTEST_MARKERS" \
-        --csv "$csv_file" \
-        --junitxml "$xml_file" \
-        $file
+    timeout "$TEST_TIMEOUT" \
+        torchrun --standalone --nproc_per_node=$NUM_GPUS -m pytest \
+            --showlocals --tb=long -v -s -m "$PYTEST_MARKERS" \
+            --csv "$csv_file" \
+            --junitxml "$xml_file" \
+            $file
     rc=$?
 
-    if [[ $rc -ne 0 ]]; then
+    if [[ $rc -eq 124 ]]; then
+        echo "TIMEOUT: $file exceeded ${TEST_TIMEOUT}s — marking as failed."
+        ANY_FAIL=1
+    elif [[ $rc -ne 0 ]]; then
         echo "Test failed in $file."
         ANY_FAIL=1
     fi


### PR DESCRIPTION
## Summary

- Add a 30-minute `timeout` wrapper around each `torchrun` invocation in `run_unit_tests.sh`
- Exit code `124` (timeout) is caught and reported as a test failure
- `TEST_TIMEOUT` env var allows overriding the limit without changing the script

## Root Cause

`test_model_configs.py` (684 tests × 8 torchrun processes) was hanging for the entire 12h CI job timeout after the MORI commit (`26912eb`), which added early MORI shmem bootstrap and a new `mori_ep` process group registration in `pretrain_gpt.py` and `fused_a2a.py`. This appears to cause a deadlock in distributed process group initialization when `torchrun --nproc_per_node=8` spawns workers for this test file.

Without a per-file timeout, one hung `torchrun` blocks all subsequent test files and consumes the entire 12h CI budget:
- Run [29034209991](https://github.com/ROCm/Megatron-LM/actions/runs/29034209991/job/87193402026): last log entry at `22:13:36`, hit 12h timeout
- `test_model_configs.py` started at `T+5h44m` and hung for ~6h16m

## What changes

```bash
# Before: torchrun can hang forever per test file
torchrun --standalone --nproc_per_node=$NUM_GPUS -m pytest ... $file

# After: killed after 30 min and reported as failure
timeout "$TEST_TIMEOUT" \
    torchrun --standalone --nproc_per_node=$NUM_GPUS -m pytest ... $file
rc=$?
if [[ $rc -eq 124 ]]; then
    echo "TIMEOUT: $file exceeded ${TEST_TIMEOUT}s — marking as failed."
fi
```

## Note

The underlying deadlock in `test_model_configs.py` needs a separate investigation. This PR ensures CI fails fast and continues running remaining test files rather than hanging until the job-level timeout kills everything.