### PR TITLE
[CI] Stabilize MORI overlap and mGPU tests

### DIFF
--- a/megatron/core/transformer/moe/fused_a2a.py
+++ b/megatron/core/transformer/moe/fused_a2a.py
@@ -552,13 +552,12 @@ def init_mori_shmem(group: torch.distributed.ProcessGroup):
     """Initialize MORI shared memory using the given process group.
 
     Registers ``group`` under :data:`MORI_EP_PROCESS_GROUP_NAME` and runs
-    ``shmem_torch_process_group_init`` once per process (until
-    :func:`finalize_mori_shmem`). MORI consumes the named PG only during
+    ``shmem_torch_process_group_init`` once per process. MORI consumes the named PG only during
     bootstrap (to broadcast the shmem UID); after that the registration is
-    unused, so later calls with a rebuilt EP group are no-ops until finalize.
+    unused, so later calls with a rebuilt but equivalent EP group are no-ops.
 
-    After :func:`finalize_mori_shmem`, the next call re-registers the group and
-    re-initializes shmem (used between pytest parametrized cases).
+    Current MORI releases do not support finalizing and reinitializing shmem in
+    the same process. Call :func:`finalize_mori_shmem` only during process teardown.
     """
     global _mori_shmem_initialized
     if _mori_shmem_initialized:
@@ -593,8 +592,8 @@ def reset_mori_op():
 
     Drains the comm stream and synchronizes the device, then calls
     :meth:`~mori.ops.EpDispatchCombineOp.reset` when present and drops the
-    reference and comm stream cache. Use between pytest parametrized cases or
-    when EP layout changes so the next :func:`get_mori_op` builds a fresh op.
+    reference and comm stream cache. Use between pytest parametrized cases with
+    the same node-spanning EP layout so the next :func:`get_mori_op` builds a fresh op.
     Does not finalize symmetric memory or clear shmem staging buffers; call
     :func:`finalize_mori_shmem` at session teardown.
 
@@ -609,13 +608,12 @@ def reset_mori_op():
 
 
 def finalize_mori_shmem():
-    """Finalize MORI symmetric memory so the next test can re-bootstrap cleanly.
+    """Finalize MORI symmetric memory during process teardown.
 
     Inverse of :func:`init_mori_shmem`. Resets the cached op first, then calls
     ``mori.shmem.shmem_finalize()`` and unregisters
-    :data:`MORI_EP_PROCESS_GROUP_NAME` so :func:`init_mori_shmem` can register
-    a fresh EP process group on the next parametrized case. Safe when shmem was
-    never initialized.
+    :data:`MORI_EP_PROCESS_GROUP_NAME`. Safe when shmem was never initialized.
+    Reinitialization after this call is unsupported by current MORI releases.
     """
     reset_mori_op()
     global _mori_shmem_initialized

--- a/run_unit_tests.sh
+++ b/run_unit_tests.sh
@@ -23,6 +23,7 @@ fi
 # Prevents a single hung torchrun from consuming the entire CI time budget.
 # --kill-after=300: if SIGTERM is ignored, SIGKILL after 5 more minutes.
 TEST_TIMEOUT=${TEST_TIMEOUT:-1800}
+LONG_TEST_TIMEOUT=${LONG_TEST_TIMEOUT:-3600}
 KILL_AFTER=${KILL_AFTER:-300}
 
 # Find all test files recursively
@@ -38,8 +39,17 @@ for file in $TEST_FILES; do
     csv_file="$OUT_DIR/test_report_${test_name}.csv"
     xml_file="$OUT_DIR/junit_report_${test_name}.xml"
 
+    file_timeout=$TEST_TIMEOUT
+    case "$file" in
+        tests/unit_tests/dist_checkpointing/models/test_moe_experts.py | \
+        tests/unit_tests/dist_checkpointing/test_layer_wise_optimizer.py)
+            # These heavily parametrized files exceed 30 minutes on MI325X.
+            file_timeout=$LONG_TEST_TIMEOUT
+            ;;
+    esac
+
     echo "Running test file: $file"
-    timeout --kill-after="$KILL_AFTER" "$TEST_TIMEOUT" \
+    timeout --kill-after="$KILL_AFTER" "$file_timeout" \
         torchrun --standalone --nproc_per_node=$NUM_GPUS -m pytest \
             --showlocals --tb=long -v -s -m "$PYTEST_MARKERS" \
             --csv "$csv_file" \
@@ -49,7 +59,7 @@ for file in $TEST_FILES; do
 
     # exit code 124 = SIGTERM timeout; 137 = SIGKILL (--kill-after triggered)
     if [[ $rc -eq 124 ]] || [[ $rc -eq 137 ]]; then
-        echo "TIMEOUT: $file exceeded ${TEST_TIMEOUT}s (kill-after=${KILL_AFTER}s) — marking as failed."
+        echo "TIMEOUT: $file exceeded ${file_timeout}s (kill-after=${KILL_AFTER}s) — marking as failed."
         ANY_FAIL=1
     elif [[ $rc -ne 0 ]]; then
         echo "Test failed in $file."

--- a/tests/unit_tests/a2a_overlap/test_schedule_chunk_1f1b.py
+++ b/tests/unit_tests/a2a_overlap/test_schedule_chunk_1f1b.py
@@ -22,8 +22,6 @@ from tests.unit_tests.a2a_overlap.utils import (
     get_test_config,
     get_valid_fp8_flags,
     get_valid_token_dispatcher_types,
-    is_mori_available,
-    reinitialize_model_parallel_for_mori,
 )
 from tests.unit_tests.test_utilities import Utils
 
@@ -85,13 +83,6 @@ class TestA2AOverlap:
         set_streams()
 
     def teardown_method(self, method):
-        # Full MORI teardown so the next parametrized case (different tp/ep layout)
-        # cannot inherit shmem staging or a stale EpDispatchCombineOp handle. These
-        # are safe no-ops when MORI is not installed.
-        from megatron.core.transformer.moe.fused_a2a import finalize_mori_shmem, reset_mori_op
-
-        reset_mori_op()
-        finalize_mori_shmem()
         Utils.destroy_model_parallel()
 
     @pytest.mark.skipif(not is_te_min_version("1.9.0.dev0"), reason="Requires TE >= 1.9.0.dev0")
@@ -302,30 +293,21 @@ class TestA2AOverlap:
             gc.collect()
             torch.cuda.empty_cache()
 
-    @pytest.mark.skipif(not is_te_min_version("1.9.0.dev0"), reason="Requires TE >= 1.9.0.dev0")
-    @pytest.mark.skipif(not is_mori_available(), reason="MORI is not available")
-    @pytest.mark.parametrize("layers", [[2, 1], [1, 1]])
-    @pytest.mark.parametrize("use_padding_mask", [False, True])
-    @pytest.mark.parametrize("tp_size", [1, 2, 4, 8])
-    def test_1f1b_schedule_model_chunk_mori(self, layers, use_padding_mask, tp_size):
+    @staticmethod
+    def run_1f1b_schedule_model_chunk_mori(layers, use_padding_mask, tp_size, ep_size):
         """
         Verifies all-to-all overlap optimization with the MORI EP backend produces the
         same results as the reference implementation.
 
-        MORI is kept in a dedicated test (rather than the shared parametrization) because
+        MORI is kept in a dedicated test file (rather than the shared parametrization) because
         its ``EpDispatchCombineHandle`` requires the expert (EP) communicator to span whole
-        nodes. This test re-initializes a node-spanning expert-parallel layout
+        nodes. The dedicated test initializes a node-spanning expert-parallel layout
         (EP=gpus_per_node, ETP=1) with ``TP`` folded in independently (parallel folding, so
         ``TP * EP`` need not equal the node width); it fully owns this layout because
         interleaving the re-init with the sub-node cases in the parametrized tests corrupts
         the shared process-group state and desyncs collectives. Skipped when the node's GPU
         count is not a power of two.
         """
-        # Re-initialize with a node-spanning expert-parallel layout so the MORI expert
-        # communicator aligns to the node (EP == gpus_per_node). TP folds in independently.
-        # Skips when the node GPU count is not a power of two.
-        ep_size = reinitialize_model_parallel_for_mori(tp_size)
-
         microbatches = 1
 
         gpt_models = []
@@ -387,11 +369,25 @@ class TestA2AOverlap:
 
             # compare results
             atol, rtol = get_compare_tolerances(flex_backend)
+            compare_failures = []
             for i in range(len(ref_captures)):
                 comp_res = compare_captures(
                     ref_captures[i], a2a_captures[i], True, True, atol=atol, rtol=rtol
                 )
-                assert comp_res[0], f"[rank {torch.distributed.get_rank()}] {comp_res[1]}"
+                if not comp_res[0]:
+                    compare_failures.append(f"model {i}: {comp_res[1]}")
+
+            # A rank-local assertion strands the remaining ranks in a later collective
+            # and turns a numerical failure into a long hang.
+            any_failure = torch.tensor(
+                [bool(compare_failures)], dtype=torch.int32, device="cuda"
+            )
+            torch.distributed.all_reduce(any_failure, op=torch.distributed.ReduceOp.MAX)
+            assert not any_failure.item(), (
+                f"[rank {torch.distributed.get_rank()}] layers={layers}, "
+                f"padding={use_padding_mask}: "
+                + ("; ".join(compare_failures) or "capture mismatch on another rank")
+            )
 
             # release resources is necessary, otherwise later testcases will oom
             for i in range(len(schedule_plans)):

--- a/tests/unit_tests/a2a_overlap/test_schedule_chunk_1f1b_mori.py
+++ b/tests/unit_tests/a2a_overlap/test_schedule_chunk_1f1b_mori.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+
+import pytest
+
+from megatron.core.utils import is_te_min_version
+from tests.unit_tests.a2a_overlap.test_schedule_chunk_1f1b import (
+    TestA2AOverlap as _ChunkScheduleTests,
+)
+from tests.unit_tests.a2a_overlap.utils import (
+    is_mori_available,
+    reinitialize_model_parallel_for_mori,
+)
+from tests.unit_tests.test_utilities import Utils
+
+
+class TestA2AOverlapMori:
+    """Run process-scoped MORI coverage in a fresh torchrun invocation."""
+
+    def teardown_method(self, method):
+        # Keep process-scoped MORI symmetric allocations alive while TP changes.
+        Utils.destroy_model_parallel()
+
+    @classmethod
+    def teardown_class(cls):
+        from megatron.core.transformer.moe.fused_a2a import finalize_mori_shmem
+
+        finalize_mori_shmem()
+
+    @pytest.mark.skipif(not is_te_min_version("1.9.0.dev0"), reason="Requires TE >= 1.9.0.dev0")
+    @pytest.mark.skipif(not is_mori_available(), reason="MORI is not available")
+    @pytest.mark.parametrize("tp_size", [1, 2, 4, 8])
+    def test_1f1b_schedule_model_chunk_mori(self, tp_size):
+        ep_size = reinitialize_model_parallel_for_mori(tp_size)
+        for use_padding_mask in (False, True):
+            for layers in ([2, 1], [1, 1]):
+                _ChunkScheduleTests.run_1f1b_schedule_model_chunk_mori(
+                    layers, use_padding_mask, tp_size, ep_size
+                )

--- a/tests/unit_tests/a2a_overlap/test_schedule_layer_1f1b.py
+++ b/tests/unit_tests/a2a_overlap/test_schedule_layer_1f1b.py
@@ -260,14 +260,18 @@ class TestA2AOverlap:
         )
 
     def teardown_method(self, method):
-        # Full MORI teardown so the next parametrized case (different tp/ep layout)
-        # cannot inherit shmem staging or a stale EpDispatchCombineOp handle. These
-        # are safe no-ops when MORI is not installed.
-        from megatron.core.transformer.moe.fused_a2a import finalize_mori_shmem, reset_mori_op
+        # MORI symmetric memory cannot be finalized and reinitialized safely in the
+        # same process. Drop the per-case op, but keep shmem alive until the class ends.
+        from megatron.core.transformer.moe.fused_a2a import reset_mori_op
 
         reset_mori_op()
-        finalize_mori_shmem()
         Utils.destroy_model_parallel()
+
+    @classmethod
+    def teardown_class(cls):
+        from megatron.core.transformer.moe.fused_a2a import finalize_mori_shmem
+
+        finalize_mori_shmem()
 
     @pytest.mark.skipif(not is_te_min_version("1.9.0.dev0"), reason="Requires TE >= 1.9.0.dev0")
     def test_transformer_layer_overlap_dense(self):

--- a/tests/unit_tests/resharding/test_model_swap.py
+++ b/tests/unit_tests/resharding/test_model_swap.py
@@ -82,6 +82,29 @@ def _build_pg_collection(
     )
 
 
+def _destroy_pg_collections(*collections: ProcessGroupCollection) -> None:
+    """Destroy custom groups that are not tracked by model-parallel state."""
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+    pg_map = dist.distributed_c10d._world.pg_map
+    groups = []
+    seen = set()
+    for collection in collections:
+        for group in vars(collection).values():
+            if not isinstance(group, dist.ProcessGroup) or group in seen:
+                continue
+            seen.add(group)
+            groups.append(group)
+
+    for group in reversed(groups):
+        if group in pg_map:
+            dist.destroy_process_group(group)
+
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+
 def _build_gpt(
     config: TransformerConfig,
     vocab_size: int,
@@ -160,6 +183,7 @@ def _set_pg_collection(module, tp_group, dp_group):
     ],
 )
 def test_swap_gpt_parametrized(
+    request: pytest.FixtureRequest,
     refit_backend: str,
     src_tp: int,
     src_pp: int,
@@ -203,8 +227,12 @@ def test_swap_gpt_parametrized(
     )
 
     # Build PGs and models (always use unified PG builder so we can set EP)
+    custom_pg_collections = []
+    request.addfinalizer(lambda: _destroy_pg_collections(*custom_pg_collections))
     src_pgs = _build_pg_collection(tp_size=src_tp, pp_size=src_pp, ep_size=src_ep)
+    custom_pg_collections.append(src_pgs)
     dst_pgs = _build_pg_collection(tp_size=dst_tp, pp_size=dst_pp, ep_size=dst_ep)
+    custom_pg_collections.append(dst_pgs)
     # Apply EP configuration to TransformerConfigs when MoE is requested
     src_cfg = copy.deepcopy(cfg)
     dst_cfg = copy.deepcopy(cfg)

--- a/tests/unit_tests/test_utilities.py
+++ b/tests/unit_tests/test_utilities.py
@@ -65,7 +65,7 @@ class Utils:
                 backend='nccl', world_size=Utils.world_size, rank=Utils.rank, store=store
             )
 
-            torch.distributed.barrier()
+            torch.distributed.barrier(device_ids=[Utils.rank % torch.cuda.device_count()])
         Utils.inited = True
 
     @staticmethod
@@ -85,6 +85,28 @@ class Utils:
             Utils.rank = rank
 
     @staticmethod
+    def _destroy_model_parallel_process_groups():
+        process_groups = ps._global_process_group_list
+        if process_groups is None:
+            return
+
+        # Tests with communication overlap can return while the final subgroup
+        # collective is still queued. Do not abort it by tearing down the group.
+        torch.cuda.synchronize()
+        try:
+            from transformer_engine.pytorch.fp8 import FP8GlobalStateManager
+        except ImportError:
+            pass
+        else:
+            # TE caches the amax-reduction group across autocast contexts.
+            FP8GlobalStateManager.reset()
+
+        pg_map = torch.distributed.distributed_c10d._world.pg_map
+        for group in reversed(process_groups):
+            if group is not None and group in pg_map:
+                torch.distributed.destroy_process_group(group)
+
+    @staticmethod
     def destroy_model_parallel():
         os.environ.pop('NVTE_FLASH_ATTN', None)
         os.environ.pop('NVTE_FUSED_ATTN', None)
@@ -92,6 +114,7 @@ class Utils:
         if not Utils.inited:
             return
         torch.distributed.barrier()
+        Utils._destroy_model_parallel_process_groups()
         ps.destroy_model_parallel()
         Utils.inited = False
 
@@ -108,6 +131,9 @@ class Utils:
         os.environ.pop('NVTE_FUSED_ATTN', None)
         os.environ.pop('NVTE_UNFUSED_ATTN', None)
 
+        if ps._global_process_group_list is not None:
+            torch.distributed.barrier()
+            Utils._destroy_model_parallel_process_groups()
         ps.destroy_model_parallel()
         Utils.initialize_distributed()
         ps.initialize_model_parallel(

--- a/tests/unit_tests/transformer/moe/conftest.py
+++ b/tests/unit_tests/transformer/moe/conftest.py
@@ -10,7 +10,11 @@ import pytest
 import torch
 import torch.distributed
 
-from megatron.core.transformer.moe.fused_a2a import HAVE_MORI, finalize_mori_shmem
+from megatron.core.transformer.moe.fused_a2a import (
+    HAVE_MORI,
+    finalize_mori_shmem,
+    reset_mori_op,
+)
 import megatron.core.parallel_state as parallel_state
 from megatron.core.utils import is_te_min_version
 from tests.unit_tests.dist_checkpointing import TempNamedDir
@@ -68,11 +72,21 @@ def moe_model_parallel_teardown(monkeypatch):
     )
     yield
     if HAVE_MORI:
-        finalize_mori_shmem()
+        # MORI shmem is process-scoped and cannot be finalized then initialized
+        # again safely. Only reset the per-test dispatch/combine operator here.
+        reset_mori_op()
     # Safety net: a test that errors before its own teardown would otherwise
     # leak NCCL/RCCL subgroups into the next test.
     if Utils.inited:
         _destroy_model_parallel_with_subgroups()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def mori_session_teardown(cleanup):
+    """Finalize MORI once, before the parent session fixture destroys the default group."""
+    yield
+    if HAVE_MORI:
+        finalize_mori_shmem()
 
 
 def pytest_sessionfinish(session, exitstatus):

--- a/tests/unit_tests/transformer/moe/test_token_dispatcher.py
+++ b/tests/unit_tests/transformer/moe/test_token_dispatcher.py
@@ -2,6 +2,7 @@
 
 import copy
 import dataclasses
+import os
 
 import pytest
 import torch
@@ -9,7 +10,7 @@ import torch
 from megatron.core import config, parallel_state
 from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_local_spec
 from megatron.core.transformer.moe.moe_layer import MoELayer
-from megatron.core.transformer.moe.fused_a2a import finalize_mori_shmem
+from megatron.core.transformer.moe.fused_a2a import reset_mori_op
 from megatron.core.transformer.moe.moe_utils import get_capacity
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.typed_torch import apply_module
@@ -475,6 +476,16 @@ def is_mori_available():
 
     return HAVE_MORI
 
+
+def require_node_spanning_mori_ep(ep_size):
+    gpus_per_node = int(os.environ.get("LOCAL_WORLD_SIZE", torch.cuda.device_count()))
+    if ep_size != gpus_per_node:
+        pytest.skip(
+            f"MORI requires a node-spanning EP group; got ep_size={ep_size}, "
+            f"gpus_per_node={gpus_per_node}"
+        )
+
+
 @pytest.mark.skipif(
     not is_deep_ep_available() and not is_hybrid_ep_available() and not is_mori_available(),
     reason="Deep EP, Hybrid EP, and MORI are not available",
@@ -484,10 +495,7 @@ class TestFlexDispatcher:
         pass
 
     def teardown_method(self, method):
-        # Full MORI teardown so the next parametrized case (different tp/ep →
-        # num_local_experts, router_topk) cannot inherit shmem staging or a
-        # stale EpDispatchCombineOp handle from the previous test.
-        finalize_mori_shmem()
+        reset_mori_op()
         Utils.destroy_model_parallel()
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
@@ -502,6 +510,8 @@ class TestFlexDispatcher:
             pytest.skip("Hybrid EP is not available")
         if moe_flex_dispatcher_backend == "mori" and not is_mori_available():
             pytest.skip("MORI is not available")
+        if moe_flex_dispatcher_backend == "mori":
+            require_node_spanning_mori_ep(ep_size)
         if permute_fusion:
             config.ENABLE_EXPERIMENTAL = True
         mori_kwargs = {}
@@ -540,6 +550,8 @@ class TestFlexDispatcher:
             pytest.skip("Hybrid EP is not available")
         if moe_flex_dispatcher_backend == "mori" and not is_mori_available():
             pytest.skip("MORI is not available")
+        if moe_flex_dispatcher_backend == "mori":
+            require_node_spanning_mori_ep(ep_size)
         if permute_fusion:
             config.ENABLE_EXPERIMENTAL = True
         mori_kwargs = {}
@@ -583,6 +595,8 @@ class TestFlexDispatcher:
             pytest.skip("Hybrid EP is not available")
         if moe_flex_dispatcher_backend == "mori" and not is_mori_available():
             pytest.skip("MORI is not available")
+        if moe_flex_dispatcher_backend == "mori":
+            require_node_spanning_mori_ep(ep_size)
         if permute_fusion:
             config.ENABLE_EXPERIMENTAL = True
         mori_kwargs = {}
@@ -615,7 +629,7 @@ class TestMoriSharedOp:
         pass
 
     def teardown_method(self, method):
-        finalize_mori_shmem()
+        reset_mori_op()
         Utils.destroy_model_parallel()
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
@@ -625,6 +639,7 @@ class TestMoriSharedOp:
     def test_multi_layer_multi_iter_forward_backward(
         self, tp_size, ep_size, num_layers, num_iters
     ):
+        require_node_spanning_mori_ep(ep_size)
         container = MoEModelTestContainer(
             tp_size=tp_size,
             ep_size=ep_size,


### PR DESCRIPTION
## Summary

- Give the initial NCCL barrier the rank's selected GPU and explicitly clean up model-parallel/custom process groups between topology changes.
- Treat MORI shared memory as process-scoped, keep its reusable outputs private across overlapped launches, and only exercise valid node-spanning MORI EP layouts.
- Run chunk-schedule MORI coverage in a fresh `torchrun` file, group all four data variants under each TP topology lifetime, and make numerical failure collective so one rank cannot strand the others.
- Give the two measured long-running checkpoint files a 60-minute per-file timeout instead of the normal 30 minutes.

## Root cause

There were two independent failures:

1. The original node-dependent GPU wedge followed the host amdgpu/KFD version, not the container. The investigation nodes were remediated to the stable 6.12.12 driver.
2. After that remediation, untouched `rocm_dev` still reproduced a MORI `ShmemStates::CheckStatusValid()` abort. MORI shared memory/operator state is process-scoped. The chunk-schedule file first ran 38 topology-changing non-MORI cases and then repeatedly tore down/recreated MORI state across 16 cases. On e04 this corrupted later MORI cases. A fresh process alone was insufficient; keeping one operator alive and running the four data variants under each TP topology lifetime was stable.

## Validation

Final commit `1474683cf`:

- Full CI passed on `quanta-ccs-aus-e04-01` in 4h18m: https://github.com/ROCm/Megatron-LM/actions/runs/30291268495
- All 178 JUnit reports were produced: 4,195 tests, 789 skipped, 0 failures, 0 errors.
- `test_fp8_param.py` passed after restoring the proven TE cache reset.
- The grouped MORI schedule passed all 16 combinations.
- The trimmed targeted suite passed on `quanta-ccs-aus-e04-01` in 22m08s and on `dell300x-ccs-aus-e11-21` in 18m34s.
- Targeted runs included three fresh-process MORI repetitions, every formerly hanging MoE/A2A file, and model swap.
- No NCCL device-guessing warning appeared.
- `py_compile`, `bash -n run_unit_tests.sh`, and `git diff --check` passed.

Previous full CI with both retained blocks also passed on both node models:

- e04: https://github.com/ROCm/Megatron-LM/actions/runs/30081613858
- Dell: https://github.com/ROCm/Megatron-LM/actions/runs/29904875199